### PR TITLE
Task list for what's remaining to get a complete clvm implementation in dotnet.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/clvm-dotnet.tests/bin/Debug/net7.0/clvm-dotnet.tests.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/clvm-dotnet.tests",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/clvm-dotnet.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/src/clvm-dotnet.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/src/clvm-dotnet.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This repo is a dotnet port of chia-networks CLVM located at https://github.com/C
 | EvalError.py  | :heavy_check_mark: |
 | Costs.py  | :heavy_check_mark: |
 | Casts.py  | :heavy_check_mark: |
-| Core_ops.py  | ❌ |
+| Core_ops.py  | :heavy_check_mark: |
 | More_ops.py  | ❌ |
-| Op_Utils.py  | ❌  |
-| Operators.py  | ❌ |
-| Serialize.py  | ❌ |
-| SExp.py  | ❌ |
+| Op_Utils.py  | :heavy_check_mark:  |
+| Operators.py  | :heavy_check_mark: |
+| Serialize.py  | :heavy_check_mark: |
+| SExp.py  | :heavy_check_mark: |
 | As_Python.py  | ❌ |
 | All Tests  | ❌ |
 

--- a/WHATSLEFT.md
+++ b/WHATSLEFT.md
@@ -3,7 +3,7 @@ This has been pretty much a straight port from the chia clvm repo, with converti
 
 | Code | Description | Who is working on it |
 | -------- | ------- |
-| More_Options | he bulk of the implementation needs completing. |  |
-| | | |
+| More_Options | the bulk of the implementation needs completing. |  |
+| All tests | tests | |
 | | | |
 

--- a/WHATSLEFT.md
+++ b/WHATSLEFT.md
@@ -1,0 +1,9 @@
+This has been pretty much a straight port from the chia clvm repo, with converting the existing code written in python as per my understanding of what it was doing. Perhaps we can maintain a table of what needs doing and who is picking it up.
+
+
+| Code | Description | Who is working on it |
+| -------- | ------- |
+| More_Options | he bulk of the implementation needs completing. |  |
+| | | |
+| | | |
+

--- a/src/clvm-dotnet.tests/BitMaskTests.cs
+++ b/src/clvm-dotnet.tests/BitMaskTests.cs
@@ -4,21 +4,21 @@ namespace clvm_dotnet.tests;
 
 public class BitMaskTests
 {
-    [Fact]
-    public void TestMsbMask()
+    [Theory]
+    [InlineData(0x00, 0x00)]
+    [InlineData(0x01, 0x01)]
+    [InlineData(0x02, 0x02)]
+    [InlineData(0x04, 0x04)]
+    [InlineData(0x08, 0x08)]
+    [InlineData(0x10, 0x10)]
+    [InlineData(0x20, 0x20)]
+    [InlineData(0x40, 0x40)]
+    [InlineData(0x80, 0x80)]
+    [InlineData(0x40, 0x44)]
+    [InlineData(0x20, 0x2A)]
+    [InlineData(0x80, 0xFF)]
+    public void TestMsbMask(byte expectedbyte, byte MSB)
     {
-        Assert.Equal(0x00, HelperFunctions.MSBMask(0x00));
-        Assert.Equal(0x01, HelperFunctions.MSBMask(0x01));
-        Assert.Equal(0x02, HelperFunctions.MSBMask(0x02));
-        Assert.Equal(0x04, HelperFunctions.MSBMask(0x04));
-        Assert.Equal(0x08, HelperFunctions.MSBMask(0x08));
-        Assert.Equal(0x10, HelperFunctions.MSBMask(0x10));
-        Assert.Equal(0x20, HelperFunctions.MSBMask(0x20));
-        Assert.Equal(0x40, HelperFunctions.MSBMask(0x40));
-        Assert.Equal(0x80, HelperFunctions.MSBMask(0x80));
-        Assert.Equal(0x40, HelperFunctions.MSBMask(0x44));
-        Assert.Equal(0x20, HelperFunctions.MSBMask(0x2A));
-        Assert.Equal(0x80, HelperFunctions.MSBMask(0xFF));
-        Assert.Equal(0x08, HelperFunctions.MSBMask(0x0F));
+        Assert.Equal(expectedbyte, HelperFunctions.MSBMask(MSB));
     }
 }

--- a/src/clvm-dotnet.tests/BitMaskTests.cs
+++ b/src/clvm-dotnet.tests/BitMaskTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace clvm_dotnet.tests;
+
+public class BitMaskTests
+{
+    [Fact]
+    public void TestMsbMask()
+    {
+        Assert.Equal(0x00, HelperFunctions.MSBMask(0x00));
+        Assert.Equal(0x01, HelperFunctions.MSBMask(0x01));
+        Assert.Equal(0x02, HelperFunctions.MSBMask(0x02));
+        Assert.Equal(0x04, HelperFunctions.MSBMask(0x04));
+        Assert.Equal(0x08, HelperFunctions.MSBMask(0x08));
+        Assert.Equal(0x10, HelperFunctions.MSBMask(0x10));
+        Assert.Equal(0x20, HelperFunctions.MSBMask(0x20));
+        Assert.Equal(0x40, HelperFunctions.MSBMask(0x40));
+        Assert.Equal(0x80, HelperFunctions.MSBMask(0x80));
+        Assert.Equal(0x40, HelperFunctions.MSBMask(0x44));
+        Assert.Equal(0x20, HelperFunctions.MSBMask(0x2A));
+        Assert.Equal(0x80, HelperFunctions.MSBMask(0xFF));
+        Assert.Equal(0x08, HelperFunctions.MSBMask(0x0F));
+    }
+}

--- a/src/clvm-dotnet.tests/CastsTests.cs
+++ b/src/clvm-dotnet.tests/CastsTests.cs
@@ -6,54 +6,64 @@ namespace clvm_dotnet.tests;
 public class CastsTests
 {
     [Theory]
-    [InlineData(0, new byte[] {}  )]
-    [InlineData(1, new byte[]  { 0x01} )]
-    [InlineData(8, new byte[]  { 0x08} )]
-    [InlineData(16, new byte[]  { 0x10} )]
-    [InlineData(32, new byte[]  { 32} )]
-    [InlineData(64, new byte[]  { 64} )]
-    [InlineData(128, new byte[]  { 0x00, 0x80} )]
-    [InlineData(256, new byte[]  { 0x01, 0x00} )]
-    [InlineData(512, new byte[]  { 0x02, 0x00 } )]
-    [InlineData(1024, new byte[]  { 0x04, 0x00 } )]
-    [InlineData(2048, new byte[]  { 0x08, 0x00} )]
-    [InlineData(4096, new byte[]  { 0x10, 0x00} )]
-    [InlineData(10241024, new byte[]  { 0x00, 0x9c, 0x44, 0x00 } )]
-    [InlineData(204820482048, new byte[]  { 0x2F, 0xB0, 0x40, 0x88, 0x00  } )]
+    [InlineData(0, new byte[] { })]
+    [InlineData(1, new byte[] { 0x01 })]
+    [InlineData(8, new byte[] { 0x08 })]
+    [InlineData(16, new byte[] { 0x10 })]
+    [InlineData(32, new byte[] { 32 })]
+    [InlineData(64, new byte[] { 64 })]
+    [InlineData(128, new byte[] { 0x00, 0x80 })]
+    [InlineData(256, new byte[] { 0x01, 0x00 })]
+    [InlineData(512, new byte[] { 0x02, 0x00 })]
+    [InlineData(1024, new byte[] { 0x04, 0x00 })]
+    [InlineData(2048, new byte[] { 0x08, 0x00 })]
+    [InlineData(4096, new byte[] { 0x10, 0x00 })]
+    [InlineData(10241024, new byte[] { 0x00, 0x9c, 0x44, 0x00 })]
+    [InlineData(204820482048, new byte[] { 0x2F, 0xB0, 0x40, 0x88, 0x00 })]
     // [InlineData(20482048204820482048, new byte[]  { 0x01, 0x1C, 0x3E, 0xDA, 0x52, 0xE0, 0xC0, 0x88, 0x00 } )]
     public void IntToBytes_returns_expectedbytes(BigInteger number, byte[] expectedBytes)
     {
         var returnedBytes = Casts.IntToBytes(number);
         Assert.Equal(expectedBytes, returnedBytes);
     }
-    
+
     [Theory]
-    [InlineData(0, new byte[] {}  )]
-    [InlineData(1, new byte[]  { 0x01} )]
-    [InlineData(8, new byte[]  { 0x08} )]
-    [InlineData(16, new byte[]  { 0x10} )]
-    [InlineData(32, new byte[]  { 32} )]
-    [InlineData(64, new byte[]  { 64} )]
-    [InlineData(128, new byte[]  { 0x00, 0x80} )]
-    [InlineData(256, new byte[]  { 0x01, 0x00} )]
-    [InlineData(512, new byte[]  { 0x02, 0x00 } )]
-    [InlineData(1024, new byte[]  { 0x04, 0x00 } )]
-    [InlineData(2048, new byte[]  { 0x08, 0x00} )]
-    [InlineData(4096, new byte[]  { 0x10, 0x00} )]
-    [InlineData(10241024, new byte[]  { 0x00, 0x9c, 0x44, 0x00 } )]
-    [InlineData(204820482048, new byte[]  { 0x2F, 0xB0, 0x40, 0x88, 0x00  } )]
+    [InlineData(0, new byte[] { })]
+    [InlineData(1, new byte[] { 0x01 })]
+    [InlineData(8, new byte[] { 0x08 })]
+    [InlineData(16, new byte[] { 0x10 })]
+    [InlineData(32, new byte[] { 32 })]
+    [InlineData(64, new byte[] { 64 })]
+    [InlineData(128, new byte[] { 0x00, 0x80 })]
+    [InlineData(256, new byte[] { 0x01, 0x00 })]
+    [InlineData(512, new byte[] { 0x02, 0x00 })]
+    [InlineData(1024, new byte[] { 0x04, 0x00 })]
+    [InlineData(2048, new byte[] { 0x08, 0x00 })]
+    [InlineData(4096, new byte[] { 0x10, 0x00 })]
+    [InlineData(10241024, new byte[] { 0x00, 0x9c, 0x44, 0x00 })]
+    [InlineData(204820482048, new byte[] { 0x2F, 0xB0, 0x40, 0x88, 0x00 })]
     // [InlineData(20482048204820482048, new byte[]  { 0x01, 0x1C, 0x3E, 0xDA, 0x52, 0xE0, 0xC0, 0x88, 0x00 } )]
     public void IntFromBytes_returns_expectedint(BigInteger expected_number, byte[] from_bytes)
     {
         var returnedBytes = Casts.IntFromBytes(from_bytes);
         Assert.Equal(expected_number, returnedBytes);
     }
-    
-    //LimbsForInt
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 1)]
+    [InlineData(8, 1)]
+    [InlineData(16, 1)]
+    [InlineData(32, 1)]
+    [InlineData(64, 1)]
+    [InlineData(128, 2)]
+    [InlineData(1024, 2)]
+    [InlineData(10241024, 4)]
+    [InlineData(204820482048, 5)]
+    // [InlineData(20482048204820482048, new byte[]  { 0x01, 0x1C, 0x3E, 0xDA, 0x52, 0xE0, 0xC0, 0x88, 0x00 } )]
+    public void LimbsForInt_returns_expectedlength(long num, int expectedNumberOfBytes)
+    {
+        var numberOfBytes = Casts.LimbsForInt(num);
+        Assert.Equal(expectedNumberOfBytes, numberOfBytes);
+    }
 }
-
-
-
-
-
-

--- a/src/clvm-dotnet.tests/CastsTests.cs
+++ b/src/clvm-dotnet.tests/CastsTests.cs
@@ -1,0 +1,59 @@
+using System.Numerics;
+using Xunit;
+
+namespace clvm_dotnet.tests;
+
+public class CastsTests
+{
+    [Theory]
+    [InlineData(0, new byte[] {}  )]
+    [InlineData(1, new byte[]  { 0x01} )]
+    [InlineData(8, new byte[]  { 0x08} )]
+    [InlineData(16, new byte[]  { 0x10} )]
+    [InlineData(32, new byte[]  { 32} )]
+    [InlineData(64, new byte[]  { 64} )]
+    [InlineData(128, new byte[]  { 0x00, 0x80} )]
+    [InlineData(256, new byte[]  { 0x01, 0x00} )]
+    [InlineData(512, new byte[]  { 0x02, 0x00 } )]
+    [InlineData(1024, new byte[]  { 0x04, 0x00 } )]
+    [InlineData(2048, new byte[]  { 0x08, 0x00} )]
+    [InlineData(4096, new byte[]  { 0x10, 0x00} )]
+    [InlineData(10241024, new byte[]  { 0x00, 0x9c, 0x44, 0x00 } )]
+    [InlineData(204820482048, new byte[]  { 0x2F, 0xB0, 0x40, 0x88, 0x00  } )]
+    // [InlineData(20482048204820482048, new byte[]  { 0x01, 0x1C, 0x3E, 0xDA, 0x52, 0xE0, 0xC0, 0x88, 0x00 } )]
+    public void IntToBytes_returns_expectedbytes(BigInteger number, byte[] expectedBytes)
+    {
+        var returnedBytes = Casts.IntToBytes(number);
+        Assert.Equal(expectedBytes, returnedBytes);
+    }
+    
+    [Theory]
+    [InlineData(0, new byte[] {}  )]
+    [InlineData(1, new byte[]  { 0x01} )]
+    [InlineData(8, new byte[]  { 0x08} )]
+    [InlineData(16, new byte[]  { 0x10} )]
+    [InlineData(32, new byte[]  { 32} )]
+    [InlineData(64, new byte[]  { 64} )]
+    [InlineData(128, new byte[]  { 0x00, 0x80} )]
+    [InlineData(256, new byte[]  { 0x01, 0x00} )]
+    [InlineData(512, new byte[]  { 0x02, 0x00 } )]
+    [InlineData(1024, new byte[]  { 0x04, 0x00 } )]
+    [InlineData(2048, new byte[]  { 0x08, 0x00} )]
+    [InlineData(4096, new byte[]  { 0x10, 0x00} )]
+    [InlineData(10241024, new byte[]  { 0x00, 0x9c, 0x44, 0x00 } )]
+    [InlineData(204820482048, new byte[]  { 0x2F, 0xB0, 0x40, 0x88, 0x00  } )]
+    // [InlineData(20482048204820482048, new byte[]  { 0x01, 0x1C, 0x3E, 0xDA, 0x52, 0xE0, 0xC0, 0x88, 0x00 } )]
+    public void IntFromBytes_returns_expectedint(BigInteger expected_number, byte[] from_bytes)
+    {
+        var returnedBytes = Casts.IntFromBytes(from_bytes);
+        Assert.Equal(expected_number, returnedBytes);
+    }
+    
+    //LimbsForInt
+}
+
+
+
+
+
+

--- a/src/clvm-dotnet.tests/SExpTests.cs
+++ b/src/clvm-dotnet.tests/SExpTests.cs
@@ -7,20 +7,12 @@ using Xunit;
 
 public class SExpTests
 {
-    /// <summary>
-    /// I believe there is a bug in Sexp.To()
-    ///
-    /// I've compared both the tree that is generated in c# and the python counterpart, and they look the same.
-    /// Disabling until the bug is fixed.
-    /// </summary>
-    [Fact(Skip = "Skpping until the ValidateSExp() method is completed")]
+    [Fact]
     public void test_case_1()
     {
         var sexp = SExp.To("foo");
         var t1 = SExp.To(new object[] { 1, sexp });
-        
-        //TODO: NOT WORKING AS EXPECTED
-        //ValidateSExp(t1);
+        ValidateSExp(t1);
     }
     
     /// <summary>
@@ -56,13 +48,13 @@ public class SExpTests
         Assert.Equal(expectedOutput, result);
     }
 
-    // [Fact]
-    // public void int_conversions()
-    // {
-    //     SExp a = SExp.To(1337);
-    //     byte[] expected = new byte[] { 0x5, 0x39 };
-    //     Assert.Equal(expected, a.AsAtom());
-    // }
+    [Fact]
+    public void int_conversions()
+    {
+        SExp a = SExp.To(1337);
+        byte[] expected = new byte[] { 0x5, 0x39 };
+        Assert.Equal(expected, a.AsAtom());
+    }
     
     // [Fact]
     // public void TestNoneBytesConversions()
@@ -135,7 +127,7 @@ public class SExpTests
         return ret;
     }
 
-    public static void ValidateSExp(SExp sexp)
+    private static void ValidateSExp(SExp sexp)
     {
         Stack<SExp> validateStack = new Stack<SExp>();
         validateStack.Push(sexp);
@@ -151,19 +143,19 @@ public class SExpTests
 
             if (v.Pair != null)
             {
-                if (!(v.Pair is Tuple<SExp,SExp>))
+                if (v.Pair.GetType() != typeof(Tuple<object,object>))
                 {
                     throw new InvalidOperationException("v.pair is not a Tuple");
                 }
 
-                Tuple<object, object> pair = v.Pair;
+                Tuple<dynamic, dynamic> pair = v.Pair;
 
                 if (!HelperFunctions.LooksLikeCLVMObject(pair.Item1) || !HelperFunctions.LooksLikeCLVMObject(pair.Item2))
                 {
                     throw new InvalidOperationException("One or both elements do not look like CLVM objects");
                 }
 
-                Tuple<dynamic, dynamic> sPair = v.AsPair();
+                var sPair = v.AsPair();
                 validateStack.Push(sPair.Item1);
                 validateStack.Push(sPair.Item2);
             }

--- a/src/clvm-dotnet.tests/SExpTests.cs
+++ b/src/clvm-dotnet.tests/SExpTests.cs
@@ -1,0 +1,56 @@
+namespace clvm_dotnet.tests;
+using Xunit;
+
+public class SExpTests
+{
+    private string PrintLeaves(SExp tree)
+    {
+        var a = tree.AsAtom();
+        if (a != null)
+        {
+            if (a.Length == 0)
+                return "() ";
+            
+            return $"{a[0]} ";
+        }
+
+        var ret = "";
+        var pairs = tree.AsPair();
+        var list = new List<SExp>() { pairs.Item1, pairs.Item2 };
+        if (pairs != null)
+        {
+            foreach (SExp i in list)
+            {
+                ret += PrintLeaves(i);
+            }
+        }
+
+        return ret;
+    }    
+    
+    public  string PrintTree(SExp tree)
+    {
+        var a = tree.AsAtom();
+        if (a != null)
+        {
+            if (a.Length == 0)
+            {
+                return "() ";
+            }
+            return $"{a[0]} ";
+        }
+
+        var ret = "(";
+        var pairs = tree.AsPair();
+        var list = new List<SExp>() { pairs.Item1, pairs.Item2 };
+        if (pairs != null)
+        {
+            foreach (var i in list)
+            {
+                ret += PrintTree(i);
+            }
+        }
+        ret += ")";
+        return ret;
+    }
+}

--- a/src/clvm-dotnet.tests/SExpTests.cs
+++ b/src/clvm-dotnet.tests/SExpTests.cs
@@ -77,6 +77,21 @@ public class SExpTests
         Assert.Equal(expected, a.AsAtom());
     }
 
+    [Theory]
+    [InlineData(new byte[]{  }, new int[] {0})] 
+    // [InlineData(new byte[] { 4, 5, 6 }, new byte[] {8,8})] 
+    // [InlineData(new byte[] { 8, 9 }, new byte[]  {256,256})]  
+    // [InlineData(new byte[] { 8, 9 }, new byte[]   {512,512,512})]  
+    // [InlineData(new byte[] { 8, 9 }, new byte[]  {1024,1024,1024,1024})]  
+    // [InlineData(new byte[] { 8, 9 }, new List<int>  {2048,248,2048,2048,2048})]  
+    public void sexp_AsBinIsInCorrectOrder(byte[] expected, int[] sexp_list)
+    {
+        SExp v = SExp.To(sexp_list);
+        var bytes = v.AsBin();
+        Assert.Equal(expected, bytes );
+    }
+
+    
     #region test helpers that should probably go into SExp object
 
     private string PrintLeaves(SExp tree)

--- a/src/clvm-dotnet.tests/SExpTests.cs
+++ b/src/clvm-dotnet.tests/SExpTests.cs
@@ -10,29 +10,17 @@ public class SExpTests
     [Fact]
     public void test_case_1()
     {
-        var sexp = SExp.To("foo");
-        var t1 = SExp.To(new object[] { 1, sexp });
+        var sexp = SExp.To(Encoding.UTF8.GetBytes("foo"));
+        var t1 = SExp.To(new dynamic[] { 1, sexp });
         ValidateSExp(t1);
     }
-    
-    /// <summary>
-    /// The python clvm has an _eq_ that attempts to cast a sexp type to the type its being compared to.
-    /// This remains incomplete until we implement and equals method that tries to do the same.
-    ///
-    /// https://github.com/Chia-Network/clvm/blob/main/clvm/SExp.py#L209
-    /// </summary>
+
     [Fact]
     public void TestWrapSExp()
     {
-        Console.WriteLine("\ntesting test wrap sexp");
-        Console.WriteLine("converting 1 to sexp");
-        
         var sexp = SExp.To(1);
         CLVMObject o = new CLVMObject(sexp);
-        byte[] expected = new byte[] { 1 };
-        
-        Console.WriteLine("Asserting equal");
-        Assert.True(o.Atom.Equals(expected));
+        Assert.True(o.Atom.Equals(1));
     }
     
     [Fact]
@@ -62,7 +50,7 @@ public class SExpTests
     }
     
     [Fact]
-    public void TestNoneBytesConversions()
+    public void TestNullConversions()
     {
         SExp a = SExp.To(null);
         byte[] expected = Array.Empty<byte>();
@@ -78,13 +66,14 @@ public class SExpTests
     }
 
     [Theory]
-    [InlineData(new byte[]{  }, new int[] {0})] 
-    // [InlineData(new byte[] { 4, 5, 6 }, new byte[] {8,8})] 
-    // [InlineData(new byte[] { 8, 9 }, new byte[]  {256,256})]  
+    [InlineData(new byte[]{ 0xFF, 0x80, 0x80  }, new int[] {0})] 
+    [InlineData(new byte[]{ 0xFF, 0x01, 0x80  }, new int[] {1})] 
+    [InlineData(new byte[] { 0xFF, 0x08, 0xFF, 0x08, 0x80}, new int[] {8,8})]
+    //[InlineData(new byte[] { 0xFF, 0x82, 0x01, 0x00, 0xFF, 0x82, 0x01, 0x00, 0x80 }, new int[]  {256,256})]  
     // [InlineData(new byte[] { 8, 9 }, new byte[]   {512,512,512})]  
     // [InlineData(new byte[] { 8, 9 }, new byte[]  {1024,1024,1024,1024})]  
     // [InlineData(new byte[] { 8, 9 }, new List<int>  {2048,248,2048,2048,2048})]  
-    public void sexp_AsBinIsInCorrectOrder(byte[] expected, int[] sexp_list)
+    public void sexp_AsBinIsCorrectOrder(byte[] expected, dynamic  sexp_list)
     {
         SExp v = SExp.To(sexp_list);
         var bytes = v.AsBin();
@@ -93,7 +82,6 @@ public class SExpTests
 
     
     #region test helpers that should probably go into SExp object
-
     private string PrintLeaves(SExp tree)
     {
         var a = tree.AsAtom();
@@ -119,7 +107,7 @@ public class SExpTests
         return ret;
     }
 
-    public string PrintTree(SExp tree)
+    private string PrintTree(SExp tree)
     {
         var a = tree.AsAtom();
         if (a != null)

--- a/src/clvm-dotnet.tests/SExpTests.cs
+++ b/src/clvm-dotnet.tests/SExpTests.cs
@@ -21,13 +21,18 @@ public class SExpTests
     ///
     /// https://github.com/Chia-Network/clvm/blob/main/clvm/SExp.py#L209
     /// </summary>
-    [Fact(Skip = "Skipping until we can mimick the equality check that the python repo does")]
+    [Fact]
     public void TestWrapSExp()
     {
-        SExp sexp = SExp.To(1);
+        Console.WriteLine("\ntesting test wrap sexp");
+        Console.WriteLine("converting 1 to sexp");
+        
+        var sexp = SExp.To(1);
         CLVMObject o = new CLVMObject(sexp);
         byte[] expected = new byte[] { 1 };
-        Assert.Equal(expected, o.Atom);
+        
+        Console.WriteLine("Asserting equal");
+        Assert.True(o.Atom.Equals(expected));
     }
     
     [Fact]
@@ -35,7 +40,7 @@ public class SExpTests
     {
         SExp a = SExp.To(new object[] { 1, 2, 3 });
         string expectedOutput = "(1 (2 (3 () )))";
-        string result = PrintTree(a);
+        string result = PrintTree(a);       
         Assert.Equal(expectedOutput, result);
     }
 

--- a/src/clvm-dotnet.tests/SExpTests.cs
+++ b/src/clvm-dotnet.tests/SExpTests.cs
@@ -1,66 +1,87 @@
+using System.Text;
+using Microsoft.VisualStudio.TestPlatform.TestHost;
+
 namespace clvm_dotnet.tests;
+
 using Xunit;
 
 public class SExpTests
 {
+    /// <summary>
+    /// I believe there is a bug in Sexp.To()
+    ///
+    /// I've compared both the tree that is generated in c# and the python counterpart, and they look the same.
+    /// Disabling until the bug is fixed.
+    /// </summary>
+    [Fact(Skip = "Skpping until the ValidateSExp() method is completed")]
+    public void test_case_1()
+    {
+        var sexp = SExp.To("foo");
+        var t1 = SExp.To(new object[] { 1, sexp });
+        
+        //TODO: NOT WORKING AS EXPECTED
+        //ValidateSExp(t1);
+    }
+    
+    /// <summary>
+    /// The python clvm has an _eq_ that attempts to cast a sexp type to the type its being compared to.
+    /// This remains incomplete until we implement and equals method that tries to do the same.
+    ///
+    /// https://github.com/Chia-Network/clvm/blob/main/clvm/SExp.py#L209
+    /// </summary>
+    [Fact(Skip = "Skipping until we can mimick the equality check that the python repo does")]
+    public void TestWrapSExp()
+    {
+        SExp sexp = SExp.To(1);
+        CLVMObject o = new CLVMObject(sexp);
+        byte[] expected = new byte[] { 1 };
+        Assert.Equal(expected, o.Atom);
+    }
+    
+    [Fact]
+    public void TestListConversions()
+    {
+        SExp a = SExp.To(new object[] { 1, 2, 3 });
+        string expectedOutput = "(1 (2 (3 () )))";
+        string result = PrintTree(a);
+        Assert.Equal(expectedOutput, result);
+    }
+
+    [Fact]
+    public void TestStringConversions()
+    {
+        SExp a = SExp.To("foobar");
+        byte[] expectedOutput = Encoding.UTF8.GetBytes("foobar");
+        byte[] result = a.AsAtom();
+        Assert.Equal(expectedOutput, result);
+    }
+
     // [Fact]
-    // public void test_case_1()
+    // public void int_conversions()
     // {
-    //     var sexp = SExp.To("foo");
-    //     var t1 = SExp.To([1, sexp]);
-    //     ValidateSExp(t1);
-    // } 
-
-    [Fact]
-    public void wrap_sexp()
-    {
-        // it's a bit of a layer violation that CLVMObject unwraps SExp, but we
-        // rely on that in a fair number of places for now. We should probably
-        // work towards phasing that out
-        // var o = new CLVMObject(SExp.To(1));
-        // Assert.Equal(o.Atom, bytes([1]);
-    }
-
-    [Fact]
-    public void list_conversions()
-    {
-        // def test_list_conversions(self):
-        // a = SExp.to([1, 2, 3])
-        // assert print_tree(a) == "(1 (2 (3 () )))"
-    }
+    //     SExp a = SExp.To(1337);
+    //     byte[] expected = new byte[] { 0x5, 0x39 };
+    //     Assert.Equal(expected, a.AsAtom());
+    // }
     
-    [Fact]
-    public void string_conversions()
-    {
-        // SExp a = SExp.To("foobar");
-        // Assert.Equal("foobar".EncodeToUtf8(), a.AsAtom());
-    }
+    // [Fact]
+    // public void TestNoneBytesConversions()
+    // {
+    //     SExp a = SExp.To(null);
+    //     byte[] expected = new byte[0];
+    //     Assert.Equal(expected, a.AsAtom());
+    // }
 
-    [Fact]
-    public void int_conversions()
-    {
-        // SExp a = SExp.To(1337);
-        // byte[] expected = new byte[] { 0x5, 0x39 };
-        // Assert.Equal(expected, a.AsAtom());
-    }
-    
-    [Fact]
-    public void TestNoneConversions()
-    {
-        // SExp a = SExp.To(null);
-        // byte[] expected = new byte[0];
-        // Assert.Equal(expected, a.AsAtom());
-    }
-    
     [Fact]
     public void empty_list_conversions()
     {
-        // SExp a = SExp.To(new object[] { });
-        // byte[] expected = new byte[0];
-        // Assert.Equal(expected, a.AsAtom());
+        SExp a = SExp.To(new object[] { });
+        byte[] expected = new byte[0];
+        Assert.Equal(expected, a.AsAtom());
     }
-    
+
     #region test helpers that should probably go into SExp object
+
     private string PrintLeaves(SExp tree)
     {
         var a = tree.AsAtom();
@@ -68,7 +89,7 @@ public class SExpTests
         {
             if (a.Length == 0)
                 return "() ";
-            
+
             return $"{a[0]} ";
         }
 
@@ -84,9 +105,9 @@ public class SExpTests
         }
 
         return ret;
-    }    
-    
-    public  string PrintTree(SExp tree)
+    }
+
+    public string PrintTree(SExp tree)
     {
         var a = tree.AsAtom();
         if (a != null)
@@ -95,6 +116,7 @@ public class SExpTests
             {
                 return "() ";
             }
+
             return $"{a[0]} ";
         }
 
@@ -108,6 +130,7 @@ public class SExpTests
                 ret += PrintTree(i);
             }
         }
+
         ret += ")";
         return ret;
     }
@@ -119,44 +142,36 @@ public class SExpTests
 
         while (validateStack.Count > 0)
         {
-            SExp v = validateStack.Pop();
+            dynamic v = validateStack.Pop();
+
             if (!(v is SExp))
             {
-                throw new Exception("Validation failed: v is not an instance of SExp.");
+                throw new InvalidOperationException("v is not an instance of SExp");
             }
 
             if (v.Pair != null)
             {
-                if (!(v.Pair is Tuple<object, object>))
+                if (!(v.Pair is Tuple<SExp,SExp>))
                 {
-                    throw new Exception("Validation failed: v.Pair is not a Tuple.");
+                    throw new InvalidOperationException("v.pair is not a Tuple");
                 }
 
-                var (v1, v2) = v.Pair;
+                Tuple<object, object> pair = v.Pair;
 
-                if (!HelperFunctions.LooksLikeCLVMObject((v1)) || !HelperFunctions.LooksLikeCLVMObject(v2))
+                if (!HelperFunctions.LooksLikeCLVMObject(pair.Item1) || !HelperFunctions.LooksLikeCLVMObject(pair.Item2))
                 {
-                    throw new Exception("Validation failed: v1 and v2 do not look like CLVM objects.");
+                    throw new InvalidOperationException("One or both elements do not look like CLVM objects");
                 }
 
-                SExp s1 = v1 as SExp;
-                SExp s2 = v2 as SExp;
-
-                if (s1 != null && s2 != null)
-                {
-                    validateStack.Push(s1);
-                    validateStack.Push(s2);
-                }
-                else
-                {
-                    throw new Exception("Validation failed: s1 and s2 are not instances of SExp.");
-                }
+                Tuple<dynamic, dynamic> sPair = v.AsPair();
+                validateStack.Push(sPair.Item1);
+                validateStack.Push(sPair.Item2);
             }
             else
             {
                 if (!(v.Atom is byte[]))
                 {
-                    throw new Exception("Validation failed: v.Atom is not a byte array.");
+                    throw new InvalidOperationException("v.atom is not a byte array");
                 }
             }
         }

--- a/src/clvm-dotnet.tests/SExpTests.cs
+++ b/src/clvm-dotnet.tests/SExpTests.cs
@@ -3,6 +3,64 @@ using Xunit;
 
 public class SExpTests
 {
+    // [Fact]
+    // public void test_case_1()
+    // {
+    //     var sexp = SExp.To("foo");
+    //     var t1 = SExp.To([1, sexp]);
+    //     ValidateSExp(t1);
+    // } 
+
+    [Fact]
+    public void wrap_sexp()
+    {
+        // it's a bit of a layer violation that CLVMObject unwraps SExp, but we
+        // rely on that in a fair number of places for now. We should probably
+        // work towards phasing that out
+        // var o = new CLVMObject(SExp.To(1));
+        // Assert.Equal(o.Atom, bytes([1]);
+    }
+
+    [Fact]
+    public void list_conversions()
+    {
+        // def test_list_conversions(self):
+        // a = SExp.to([1, 2, 3])
+        // assert print_tree(a) == "(1 (2 (3 () )))"
+    }
+    
+    [Fact]
+    public void string_conversions()
+    {
+        // SExp a = SExp.To("foobar");
+        // Assert.Equal("foobar".EncodeToUtf8(), a.AsAtom());
+    }
+
+    [Fact]
+    public void int_conversions()
+    {
+        // SExp a = SExp.To(1337);
+        // byte[] expected = new byte[] { 0x5, 0x39 };
+        // Assert.Equal(expected, a.AsAtom());
+    }
+    
+    [Fact]
+    public void TestNoneConversions()
+    {
+        // SExp a = SExp.To(null);
+        // byte[] expected = new byte[0];
+        // Assert.Equal(expected, a.AsAtom());
+    }
+    
+    [Fact]
+    public void empty_list_conversions()
+    {
+        // SExp a = SExp.To(new object[] { });
+        // byte[] expected = new byte[0];
+        // Assert.Equal(expected, a.AsAtom());
+    }
+    
+    #region test helpers that should probably go into SExp object
     private string PrintLeaves(SExp tree)
     {
         var a = tree.AsAtom();
@@ -53,4 +111,55 @@ public class SExpTests
         ret += ")";
         return ret;
     }
+
+    public static void ValidateSExp(SExp sexp)
+    {
+        Stack<SExp> validateStack = new Stack<SExp>();
+        validateStack.Push(sexp);
+
+        while (validateStack.Count > 0)
+        {
+            SExp v = validateStack.Pop();
+            if (!(v is SExp))
+            {
+                throw new Exception("Validation failed: v is not an instance of SExp.");
+            }
+
+            if (v.Pair != null)
+            {
+                if (!(v.Pair is Tuple<object, object>))
+                {
+                    throw new Exception("Validation failed: v.Pair is not a Tuple.");
+                }
+
+                var (v1, v2) = v.Pair;
+
+                if (!HelperFunctions.LooksLikeCLVMObject((v1)) || !HelperFunctions.LooksLikeCLVMObject(v2))
+                {
+                    throw new Exception("Validation failed: v1 and v2 do not look like CLVM objects.");
+                }
+
+                SExp s1 = v1 as SExp;
+                SExp s2 = v2 as SExp;
+
+                if (s1 != null && s2 != null)
+                {
+                    validateStack.Push(s1);
+                    validateStack.Push(s2);
+                }
+                else
+                {
+                    throw new Exception("Validation failed: s1 and s2 are not instances of SExp.");
+                }
+            }
+            else
+            {
+                if (!(v.Atom is byte[]))
+                {
+                    throw new Exception("Validation failed: v.Atom is not a byte array.");
+                }
+            }
+        }
+    }
+    #endregion
 }

--- a/src/clvm-dotnet.tests/SExpTests.cs
+++ b/src/clvm-dotnet.tests/SExpTests.cs
@@ -56,13 +56,13 @@ public class SExpTests
         Assert.Equal(expected, a.AsAtom());
     }
     
-    // [Fact]
-    // public void TestNoneBytesConversions()
-    // {
-    //     SExp a = SExp.To(null);
-    //     byte[] expected = new byte[0];
-    //     Assert.Equal(expected, a.AsAtom());
-    // }
+    [Fact]
+    public void TestNoneBytesConversions()
+    {
+        SExp a = SExp.To(null);
+        byte[] expected = Array.Empty<byte>();
+        Assert.Equal(expected, a.AsAtom());
+    }
 
     [Fact]
     public void empty_list_conversions()

--- a/src/clvm-dotnet.tests/SerializeTests.cs
+++ b/src/clvm-dotnet.tests/SerializeTests.cs
@@ -4,6 +4,40 @@ namespace clvm_dotnet.tests;
 
 public class SerializeTests
 {
+    
+    public void CheckSerde(dynamic s)
+    {
+        var v = SExp.To(s);
+        var b = v.AsBin();
+        var v1 = Serialize.SexpBufferFromStream(new MemoryStream(b));
+        
+        if (!v.Equals(v1))
+        {
+            Console.WriteLine($"{v}: {b.Length} {BitConverter.ToString(b)} {v1}");
+            System.Diagnostics.Debugger.Break();
+            b = v.AsBin();
+            v1 = Serialize.SexpBufferFromStream(new MemoryStream(b));
+        }
+        
+        Assert.True(v.Equals(v1));
+    }
+
+    [Fact]
+    public void EmptyString()
+    {
+        CheckSerde("");
+    }
+    
+    [Fact]
+    public void TestSingleBytes()
+    {
+        for (int _ = 0; _ < 256; _++)
+        {
+            byte[] byteArray = new byte[] { (byte)_ };
+            CheckSerde(byteArray);
+        }
+    }
+    
     [Fact]
     public void TestZero()
     {
@@ -20,7 +54,13 @@ public class SerializeTests
         byte[] inputBytes = new byte[0];
         SExp v = SExp.To(inputBytes);
         byte[] vAsBin = v.AsBin();
-        byte[] expectedBytes = new byte[] { 0x80 };
+        byte[] expectedBytes = new byte[] { 0x00 };
         Assert.Equal(expectedBytes, vAsBin);
     }
+    
+    // [Fact]
+    // public void TestPlus()
+    // {
+    //     Assert.AreEqual(OPERATOR_LOOKUP(KEYWORD_TO_ATOM["+"], SExp.To(new int[] { 3, 4, 5 }))[1], SExp.To(12));
+    // }
 }

--- a/src/clvm-dotnet.tests/SerializeTests.cs
+++ b/src/clvm-dotnet.tests/SerializeTests.cs
@@ -4,26 +4,78 @@ using BinaryReader = System.IO.BinaryReader;
 
 namespace clvm_dotnet.tests;
 
+public class InfiniteStream : Stream
+{
+    private byte[] buf;
+    private int position;
+
+    public InfiniteStream(byte[] b)
+    {
+        buf = b;
+        position = 0;
+    }
+
+    public override void Flush()
+    {
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        int bytesRead = 0;
+
+        while (count > 0 && position < buf.Length)
+        {
+            buffer[offset] = buf[position];
+            offset++;
+            position++;
+            count--;
+            bytesRead++;
+        }
+
+        return bytesRead;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => buf.Length;
+
+    public override long Position
+    {
+        get => position;
+        set => throw new NotSupportedException();
+    }
+}
+
 public class SerializeTests
 {
     private const string TEXT = "the quick brown fox jumps over the lazy dogs";
-    
-    
+
+
     [Fact]
     public void TestDeserializeEmpty()
     {
         byte[] bytesIn = Array.Empty<byte>();
-        Assert.Throws<Exception>(() =>
-        {
-           Serialize.SexpFromStream(new MemoryStream(bytesIn));
-        });
-        
-        Assert.Throws<Exception>(() =>
-        {
-            Serialize.SexpBufferFromStream(new MemoryStream(bytesIn));
-        });
+        Assert.Throws<Exception>(() => { Serialize.SexpFromStream(new MemoryStream(bytesIn)); });
+
+        Assert.Throws<Exception>(() => { Serialize.SexpBufferFromStream(new MemoryStream(bytesIn)); });
     }
-    
+
     [Fact]
     public void DeserializeTruncatedSizeTest()
     {
@@ -43,20 +95,17 @@ public class SerializeTests
         });
         Assert.Equal("Bad encoding - ConsumeAtom", error2.Message);
     }
-    
+
     [Fact]
     public void DeserializeTruncatedBlobTest()
     {
         // This is a complete length prefix. The blob is supposed to be 63 bytes,
         // but the blob itself is truncated, it's less than 63 bytes
-        
+
         //dotnet will throw an error when trying use BitConverter here anyway
         byte[] bytesIn = new byte[] { 0xBF, 0x20, 0x20, 0x20 };
-        
-        var error1 = Assert.Throws<ArgumentException>(() =>
-        {
-            Serialize.SexpFromStream(new MemoryStream(bytesIn));
-        });
+
+        var error1 = Assert.Throws<ArgumentException>(() => { Serialize.SexpFromStream(new MemoryStream(bytesIn)); });
         Assert.Contains("Destination array is not long enough to copy all the items in the collection", error1.Message);
 
 
@@ -66,51 +115,48 @@ public class SerializeTests
         });
         Assert.Contains("Destination array is not long enough to copy all the items in the collection", error1.Message);
     }
-    
-    
-    // public void CheckSerde(dynamic s)
-    // {
-    //     SExp v = SExp.To(s);
-    //     var b = v.AsBin();
-    //     var v1 = Serialize.SexFromStream(new MemoryStream(b));
-    //     
-    //     if (!v.Equals(v1))
-    //     {
-    //         Console.WriteLine($"{v}: {b.Length} {BitConverter.ToString(b)} {v1}");
-    //         System.Diagnostics.Debugger.Break();
-    //         b = v.AsBin();
-    //         v1 = Serialize.SexpBufferFromStream(new MemoryStream(b));
-    //     }
-    //     
-    //     Assert.True(v.Equals(v1));
-    // }
 
+    [Fact]
+    public void TestDeserializeLargeBlob()
+    {
+        // This length prefix is 7 bytes long, the last 6 bytes specifies the
+        // length of the blob, which is 0xffffffffffff, or (2^48 - 1)
+        // We don't support blobs this large, and we should fail immediately when
+        // exceeding the max blob size, rather than trying to read this many
+        // bytes from the stream
+        //
+        //DOT NET WILL ERROR ON BitConverter.ToUInt64(sizeBlob anyway
+        byte[] bytesIn = new byte[] { 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+
+        var error1 = Assert.Throws<ArgumentException>(() => Serialize.SexpFromStream(new InfiniteStream(bytesIn)));
+        Assert.Contains("Destination array is not long enough", error1.Message);
+
+        var error2 =
+            Assert.Throws<ArgumentException>(() => Serialize.SexpBufferFromStream(new InfiniteStream(bytesIn)));
+        Assert.Contains("Destination array is not long enough", error2.Message);
+    }
+
+    public void CheckSerde(dynamic s)
+    {
+        SExp v = SExp.To(s);
+        var b = v.AsBin();
+        var v1 = Serialize.SexpFromStream(new MemoryStream(b));
+        var isEqual = v.Equals(v1);
+        if (!isEqual)
+        {
+            Console.WriteLine($"{v}: {b.Length} {BitConverter.ToString(b)} {v1}");
+            System.Diagnostics.Debugger.Break();
+            b = v.AsBin();
+            v1 = Serialize.SexpBufferFromStream(new MemoryStream(b));
+        }
+        Assert.True(isEqual);
+    }
+    
     // [Fact]
     // public void EmptyString()
     // {
     //     CheckSerde(Array.Empty<byte>());
     // }
-    
-    #region AtomFromStream
-
-    [Fact]
-    public void AtomFromStreamEmptyString()
-    {
-        byte b = 0x80;
-        var sexp = Serialize.AtomFromStream(null, b);
-        Assert.Equal(Array.Empty<byte>(), sexp.Atom);
-    }
-    
-    [Fact]
-    public void AtomFromStreamMaxSingleByte()
-    {
-        byte b = 0x7F;
-        byte[] byteArray = new byte[] { 0x7F };
-        var sexp = Serialize.AtomFromStream(null, b);
-        Assert.Equal(byteArray, sexp.Atom);
-    }
-    #endregion
-    
     
     // [Fact]
     // public void TestSingleBytes()
@@ -122,6 +168,29 @@ public class SerializeTests
     //     }
     // }
     
+
+    #region AtomFromStream
+
+    [Fact]
+    public void AtomFromStreamEmptyString()
+    {
+        byte b = 0x80;
+        var sexp = Serialize.AtomFromStream(null, b,typeof(CLVMObject));
+        Assert.Equal(Array.Empty<byte>(), sexp.Atom);
+    }
+
+    [Fact]
+    public void AtomFromStreamMaxSingleByte()
+    {
+        byte b = 0x7F;
+        byte[] byteArray = new byte[] { 0x7F };
+        var sexp = Serialize.AtomFromStream(null, b, typeof(CLVMObject));
+        Assert.Equal(byteArray, sexp.Atom);
+    }
+
+    #endregion
+
+    
     [Fact]
     public void TestZero()
     {
@@ -131,7 +200,7 @@ public class SerializeTests
         byte[] expectedBytes = new byte[] { 0x00 };
         Assert.Equal(expectedBytes, vAsBin);
     }
-    
+
     [Fact]
     public void TestEmpty()
     {
@@ -141,24 +210,19 @@ public class SerializeTests
         byte[] expectedBytes = new byte[] { 0x80 };
         Assert.Equal(expectedBytes, vAsBin);
     }
-    
-    //[Fact]
-    // public void TestShortLists()
-    // {
-    //     for (int _ = 0; _ < 2048; _ += 8)
-    //     {
-    //         for (int size = 1; size <= 4; size++)
-    //         {
-    //             byte[] byteArray = new byte[size];
-    //             for (int i = 0; i < size; i++)
-    //             {
-    //                 byteArray[i] = (byte)_;
-    //             }
-    //             CheckSerde(byteArray);
-    //         }
-    //     }
-    // }   
-    
+
+    [Fact]
+     public void TestShortLists()
+     {
+         for (int _ = 8; _ < 16; _ += 8)
+         {
+             for (int size = 1; size < 5; size++)
+             {
+                 CheckSerde(Enumerable.Repeat(_, size).ToList());
+             }
+         }
+     }   
+
     // [Fact(Skip = "Broken for the moment")]
     // public void TestConsBox()
     // {
@@ -166,7 +230,7 @@ public class SerializeTests
     //     CheckSerde(Tuple.Create<object, object>(null, new object[] { 1, 2, 30, 40, 600, Tuple.Create<object, object>(null, 18) }));
     //     CheckSerde(Tuple.Create<object, object>(100, Tuple.Create<object, object>(TEXT, Tuple.Create<object, object>(30, Tuple.Create<object, object>(50, Tuple.Create<object, object>(90, Tuple.Create<object, object>(TEXT, TEXT + TEXT)))))));
     // }
-    
+
     // [Fact]
     // public void TestPlus()
     // {

--- a/src/clvm-dotnet.tests/SerializeTests.cs
+++ b/src/clvm-dotnet.tests/SerializeTests.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace clvm_dotnet.tests;
+
+public class SerializeTests
+{
+    [Fact]
+    public void TestZero()
+    {
+        byte[] inputBytes = new byte[] { 0x00 };
+        SExp v = SExp.To(inputBytes);
+        byte[] vAsBin = v.AsBin();
+        byte[] expectedBytes = new byte[] { 0x00 };
+        Assert.Equal(expectedBytes, vAsBin);
+    }
+    
+    [Fact]
+    public void TestEmpty()
+    {
+        byte[] inputBytes = new byte[0];
+        SExp v = SExp.To(inputBytes);
+        byte[] vAsBin = v.AsBin();
+        byte[] expectedBytes = new byte[] { 0x80 };
+        Assert.Equal(expectedBytes, vAsBin);
+    }
+}

--- a/src/clvm-dotnet.tests/SerializeTests.cs
+++ b/src/clvm-dotnet.tests/SerializeTests.cs
@@ -1,42 +1,126 @@
+using System.Runtime.InteropServices;
 using Xunit;
+using BinaryReader = System.IO.BinaryReader;
 
 namespace clvm_dotnet.tests;
 
 public class SerializeTests
 {
+    private const string TEXT = "the quick brown fox jumps over the lazy dogs";
     
-    public void CheckSerde(dynamic s)
+    
+    [Fact]
+    public void TestDeserializeEmpty()
     {
-        var v = SExp.To(s);
-        var b = v.AsBin();
-        var v1 = Serialize.SexpBufferFromStream(new MemoryStream(b));
-        
-        if (!v.Equals(v1))
+        byte[] bytesIn = Array.Empty<byte>();
+        Assert.Throws<Exception>(() =>
         {
-            Console.WriteLine($"{v}: {b.Length} {BitConverter.ToString(b)} {v1}");
-            System.Diagnostics.Debugger.Break();
-            b = v.AsBin();
-            v1 = Serialize.SexpBufferFromStream(new MemoryStream(b));
-        }
+           Serialize.SexpFromStream(new MemoryStream(bytesIn));
+        });
         
-        Assert.True(v.Equals(v1));
+        Assert.Throws<Exception>(() =>
+        {
+            Serialize.SexpBufferFromStream(new MemoryStream(bytesIn));
+        });
     }
+    
+    [Fact]
+    public void DeserializeTruncatedSizeTest()
+    {
+        // fe means the total number of bytes in the length-prefix is 7
+        // one for each bit set. 5 bytes is too few
+        byte[] bytesIn = new byte[] { 0xFE, 0x20, 0x20, 0x20, 0x20 };
+
+        var error1 = Assert.Throws<InvalidOperationException>(() =>
+        {
+            Serialize.SexpFromStream(new MemoryStream(bytesIn));
+        });
+        Assert.Equal("Bad encoding - AtomFromStream", error1.Message);
+
+        var error2 = Assert.Throws<InvalidOperationException>(() =>
+        {
+            Serialize.SexpBufferFromStream(new MemoryStream(bytesIn));
+        });
+        Assert.Equal("Bad encoding - ConsumeAtom", error2.Message);
+    }
+    
+    [Fact]
+    public void DeserializeTruncatedBlobTest()
+    {
+        // This is a complete length prefix. The blob is supposed to be 63 bytes,
+        // but the blob itself is truncated, it's less than 63 bytes
+        
+        //dotnet will throw an error when trying use BitConverter here anyway
+        byte[] bytesIn = new byte[] { 0xBF, 0x20, 0x20, 0x20 };
+        
+        var error1 = Assert.Throws<ArgumentException>(() =>
+        {
+            Serialize.SexpFromStream(new MemoryStream(bytesIn));
+        });
+        Assert.Contains("Destination array is not long enough to copy all the items in the collection", error1.Message);
+
+
+        var error2 = Assert.Throws<ArgumentException>(() =>
+        {
+            Serialize.SexpBufferFromStream(new MemoryStream(bytesIn));
+        });
+        Assert.Contains("Destination array is not long enough to copy all the items in the collection", error1.Message);
+    }
+    
+    
+    // public void CheckSerde(dynamic s)
+    // {
+    //     SExp v = SExp.To(s);
+    //     var b = v.AsBin();
+    //     var v1 = Serialize.SexFromStream(new MemoryStream(b));
+    //     
+    //     if (!v.Equals(v1))
+    //     {
+    //         Console.WriteLine($"{v}: {b.Length} {BitConverter.ToString(b)} {v1}");
+    //         System.Diagnostics.Debugger.Break();
+    //         b = v.AsBin();
+    //         v1 = Serialize.SexpBufferFromStream(new MemoryStream(b));
+    //     }
+    //     
+    //     Assert.True(v.Equals(v1));
+    // }
+
+    // [Fact]
+    // public void EmptyString()
+    // {
+    //     CheckSerde(Array.Empty<byte>());
+    // }
+    
+    #region AtomFromStream
 
     [Fact]
-    public void EmptyString()
+    public void AtomFromStreamEmptyString()
     {
-        CheckSerde("");
+        byte b = 0x80;
+        var sexp = Serialize.AtomFromStream(null, b);
+        Assert.Equal(Array.Empty<byte>(), sexp.Atom);
     }
     
     [Fact]
-    public void TestSingleBytes()
+    public void AtomFromStreamMaxSingleByte()
     {
-        for (int _ = 0; _ < 256; _++)
-        {
-            byte[] byteArray = new byte[] { (byte)_ };
-            CheckSerde(byteArray);
-        }
+        byte b = 0x7F;
+        byte[] byteArray = new byte[] { 0x7F };
+        var sexp = Serialize.AtomFromStream(null, b);
+        Assert.Equal(byteArray, sexp.Atom);
     }
+    #endregion
+    
+    
+    // [Fact]
+    // public void TestSingleBytes()
+    // {
+    //     for (int _ = 0; _ < 256; _++)
+    //     {
+    //         byte[] byteArray = new byte[] { (byte)_ };
+    //         CheckSerde(byteArray);
+    //     }
+    // }
     
     [Fact]
     public void TestZero()
@@ -54,9 +138,34 @@ public class SerializeTests
         byte[] inputBytes = new byte[0];
         SExp v = SExp.To(inputBytes);
         byte[] vAsBin = v.AsBin();
-        byte[] expectedBytes = new byte[] { 0x00 };
+        byte[] expectedBytes = new byte[] { 0x80 };
         Assert.Equal(expectedBytes, vAsBin);
     }
+    
+    //[Fact]
+    // public void TestShortLists()
+    // {
+    //     for (int _ = 0; _ < 2048; _ += 8)
+    //     {
+    //         for (int size = 1; size <= 4; size++)
+    //         {
+    //             byte[] byteArray = new byte[size];
+    //             for (int i = 0; i < size; i++)
+    //             {
+    //                 byteArray[i] = (byte)_;
+    //             }
+    //             CheckSerde(byteArray);
+    //         }
+    //     }
+    // }   
+    
+    // [Fact(Skip = "Broken for the moment")]
+    // public void TestConsBox()
+    // {
+    //     CheckSerde(Tuple.Create<object, object>(null, null));
+    //     CheckSerde(Tuple.Create<object, object>(null, new object[] { 1, 2, 30, 40, 600, Tuple.Create<object, object>(null, 18) }));
+    //     CheckSerde(Tuple.Create<object, object>(100, Tuple.Create<object, object>(TEXT, Tuple.Create<object, object>(30, Tuple.Create<object, object>(50, Tuple.Create<object, object>(90, Tuple.Create<object, object>(TEXT, TEXT + TEXT)))))));
+    // }
     
     // [Fact]
     // public void TestPlus()

--- a/src/clvm-dotnet.tests/SerializeTests.cs
+++ b/src/clvm-dotnet.tests/SerializeTests.cs
@@ -194,8 +194,8 @@ public class SerializeTests
     [Fact]
     public void TestZero()
     {
-        byte[] inputBytes = new byte[] { 0x00 };
-        SExp v = SExp.To(inputBytes);
+        byte b = 0x00;
+        SExp v = SExp.To(b);
         byte[] vAsBin = v.AsBin();
         byte[] expectedBytes = new byte[] { 0x00 };
         Assert.Equal(expectedBytes, vAsBin);
@@ -214,11 +214,11 @@ public class SerializeTests
     [Fact]
      public void TestShortLists()
      {
-         for (int _ = 8; _ < 16; _ += 8)
+         for (int _ = 8; _ < 36; _ += 8)
          {
              for (int size = 1; size < 5; size++)
              {
-                 CheckSerde(Enumerable.Repeat(_, size).ToList());
+                 CheckSerde(Enumerable.Repeat(_, size).ToArray());
              }
          }
      }   

--- a/src/clvm-dotnet/CLVMObject.cs
+++ b/src/clvm-dotnet/CLVMObject.cs
@@ -11,7 +11,6 @@ public class CLVMObject
 
     public CLVMObject(object v)
     {
-        Console.WriteLine("\ninitiating CLVMObject class");
         if (v is CLVMObject clvmObj)
         {
             Atom = clvmObj.Atom;
@@ -36,7 +35,6 @@ public class CLVMObject
     
     public CLVMObject()
     {
-        Console.WriteLine("\ninitiating CLVMObject class");
     }
 
     public byte[] AsAtom()

--- a/src/clvm-dotnet/CLVMObject.cs
+++ b/src/clvm-dotnet/CLVMObject.cs
@@ -6,20 +6,31 @@ namespace clvm_dotnet;
 /// </summary>
 public class CLVMObject
 {
-    public byte[]? Atom { get; set; }
-    public Tuple<dynamic,dynamic> Pair { get; set; }
+    public byte[] Atom { get;  set; }
+    public Tuple<object, object> Pair { get;  set; }
 
-    public CLVMObject(dynamic v)
+    public CLVMObject(object v)
     {
-        if (v.GetType() == typeof(Tuple<dynamic, dynamic>))
+        Console.WriteLine("initiating CLVMObject class");
+        if (v is CLVMObject clvmObj)
         {
-            Pair = v;
+            Atom = clvmObj.Atom;
+            Pair = clvmObj.Pair;
+        }
+        else if (v is Tuple<object, object> tuple)
+        {
+            if (tuple.Item1 == null || tuple.Item2 == null)
+            {
+                throw new ArgumentException("Tuples must not contain null values.");
+            }
+
+            Pair = tuple;
             Atom = null;
         }
         else
         {
+            Atom = HelperFunctions.ConvertAtomToBytes(v); // Implement your conversion logic
             Pair = null;
-            Atom = v;
         }
     }
     

--- a/src/clvm-dotnet/CLVMObject.cs
+++ b/src/clvm-dotnet/CLVMObject.cs
@@ -6,12 +6,12 @@ namespace clvm_dotnet;
 /// </summary>
 public class CLVMObject
 {
-    public byte[] Atom { get;  set; }
+    public dynamic? Atom { get;  set; }
     public Tuple<object, object> Pair { get;  set; }
 
     public CLVMObject(object v)
     {
-        Console.WriteLine("initiating CLVMObject class");
+        Console.WriteLine("\ninitiating CLVMObject class");
         if (v is CLVMObject clvmObj)
         {
             Atom = clvmObj.Atom;
@@ -29,13 +29,14 @@ public class CLVMObject
         }
         else
         {
-            Atom = HelperFunctions.ConvertAtomToBytes(v); // Implement your conversion logic
+            Atom = v;
             Pair = null;
         }
     }
     
     public CLVMObject()
     {
+        Console.WriteLine("\ninitiating CLVMObject class");
     }
 
     public byte[] AsAtom()

--- a/src/clvm-dotnet/Casts.cs
+++ b/src/clvm-dotnet/Casts.cs
@@ -17,22 +17,31 @@ public static class Casts
 
     public static byte[] IntToBytes(BigInteger v)
     {
-        int byteCount = (int)((v.GetBitLength() + 7) >> 3);
-        if (v == 0)
-        {
-            return Array.Empty<byte>();
-        }
-        byte[] result = v.ToByteArray(isBigEndian: true);
+        byte[] byteArray = v.ToByteArray();
         
-        // Ensure the returned byte array is minimal
-        while (result.Length > 1 && (result[0] == 0xFF && (result[1] & 0x80) != 0 || result[0] == 0))
+        if (BitConverter.IsLittleEndian)
         {
-            byte[] trimmedResult = new byte[result.Length - 1];
-            Array.Copy(result, 1, trimmedResult, 0, trimmedResult.Length);
-            result = trimmedResult;
+            byteArray = byteArray.Reverse().ToArray();
         }
-        
-        return result;
+
+        while (byteArray.Length > 1 && (byteArray[0] == 0xFF || byteArray[0] == 0x00))
+        {
+            byteArray = byteArray.Skip(1).ToArray();
+        }
+
+        if (!v.IsZero)
+        {
+            if (byteArray[0] >= 0x80)
+            {
+                byteArray = new byte[] { 0 }.Concat(byteArray).ToArray();
+            }
+        }
+        else
+        {
+            byteArray = new byte[0];
+        }
+
+        return byteArray;
     }
 
     public static int LimbsForInt(BigInteger v)

--- a/src/clvm-dotnet/Casts.cs
+++ b/src/clvm-dotnet/Casts.cs
@@ -46,6 +46,6 @@ public static class Casts
 
     public static int LimbsForInt(BigInteger v)
     {
-        return (int)((v.GetBitLength() + 7) >> 3);
+        return IntToBytes(v).Length;
     }
 }

--- a/src/clvm-dotnet/HelperFunctions.cs
+++ b/src/clvm-dotnet/HelperFunctions.cs
@@ -205,4 +205,12 @@ public static class HelperFunctions
 
         return false;
     }
+    
+    public static byte MSBMask(byte inputByte)
+    {
+        inputByte |= (byte)(inputByte >> 1);
+        inputByte |= (byte)(inputByte >> 2);
+        inputByte |= (byte)(inputByte >> 4);
+        return (byte)((inputByte + 1) >> 1);
+    }
 }

--- a/src/clvm-dotnet/HelperFunctions.cs
+++ b/src/clvm-dotnet/HelperFunctions.cs
@@ -10,7 +10,7 @@ public static class HelperFunctions
 {
     private static byte[] nullBytes = new byte[0];
 
-    public static dynamic ToSexpType(dynamic? v)
+    public static dynamic? ToSexpType(dynamic? v)
     {
         List<object> stack = new List<object> { v };
         List<(int op, int target)> ops = new List<(int op, int target)> { (0, -1) }; // convert
@@ -175,28 +175,31 @@ public static class HelperFunctions
         throw new ArgumentException($"Can't cast {v.GetType()} ({v}) to bytes");
     }
 
-    public static bool LooksLikeCLVMObject(object o)
+    public static bool LooksLikeCLVMObject(object? o)
     {
-        Type type = o.GetType();
-        PropertyInfo[] properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-        bool hasAtom = false;
-        bool hasPair = false;
-
-        foreach (PropertyInfo property in properties)
+        if (o != null)
         {
-            if (property.Name == "Atom")
-            {
-                hasAtom = true;
-            }
-            else if (property.Name == "Pair")
-            {
-                hasPair = true;
-            }
+            Type type = o.GetType();
+            PropertyInfo[] properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
-            if (hasAtom && hasPair)
+            bool hasAtom = false;
+            bool hasPair = false;
+
+            foreach (PropertyInfo property in properties)
             {
-                return true;
+                if (property.Name == "Atom")
+                {
+                    hasAtom = true;
+                }
+                else if (property.Name == "Pair")
+                {
+                    hasPair = true;
+                }
+
+                if (hasAtom && hasPair)
+                {
+                    return true;
+                }
             }
         }
 

--- a/src/clvm-dotnet/HelperFunctions.cs
+++ b/src/clvm-dotnet/HelperFunctions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.IO.Pipes;
 using System.Reflection;
 using System.Text;
 
@@ -7,98 +8,117 @@ namespace clvm_dotnet;
 
 public static class HelperFunctions
 {
-    public static readonly byte[] NULL = Array.Empty<byte>();
-    
-    public static dynamic ToSexpType(dynamic v)
-    {
-        var stack = new Stack<dynamic>();
-        var ops = new Stack<(int, int?)>();
-        ops.Push((0, null));  // convert
+    private static byte[] nullBytes = new byte[0];
 
+    public static dynamic ToSexpType(dynamic? v)
+    {
+        List<object> stack = new List<object> { v };
+        List<(int op, int target)> ops = new List<(int op, int target)> { (0, -1) }; // convert
+        int opIteration = 0;
+        
         while (ops.Count > 0)
         {
-            var (op, target) = ops.Pop();
-
+            opIteration += 1;
+            Console.WriteLine($"op iteration: {opIteration}");
+            
+            var (op, target) = ops[ops.Count - 1];
+            ops.RemoveAt(ops.Count - 1);
+            
             // Convert value
             if (op == 0)
             {
-                if (LooksLikeCLVMObject(stack.Peek()))
+                Console.WriteLine("op0");
+                if (LooksLikeCLVMObject(stack[stack.Count - 1]))
                 {
                     continue;
                 }
 
-                var value = stack.Pop();
+                object value = stack[stack.Count - 1];
+                stack.RemoveAt(stack.Count - 1);
 
                 if (value is Tuple<object, object> tuple)
                 {
-                    if (tuple.Item1 != null && tuple.Item2 != null)
+                    if (tuple.Item2 != null)
                     {
-                        target = stack.Count;
-                        stack.Push(new CLVMObject(new Tuple<CLVMObject, CLVMObject>(
-                            new CLVMObject(tuple.Item1), new CLVMObject(tuple.Item2))));
-
-                        if (!LooksLikeCLVMObject(tuple.Item2))
-                        {
-                            stack.Push(tuple.Item2);
-                            ops.Push((2, target));  // set right
-                            ops.Push((0, null));    // convert
-                        }
-
-                        if (!LooksLikeCLVMObject(tuple.Item1))
-                        {
-                            stack.Push(tuple.Item1);
-                            ops.Push((1, target));  // set left
-                            ops.Push((0, null));    // convert
-                        }
-
-                        continue;
+                        Console.WriteLine("right is not a CLVM object");
+                        stack.Add(tuple.Item2);
+                        ops.Add((2, target)); // set right
+                        ops.Add((0, -1)); // convert
                     }
-                }
 
-                if (value is List<object> list)
-                {
-                    target = stack.Count;
-                    stack.Push(new CLVMObject(NULL));
-
-                    foreach (var item in list)
+                    if (tuple.Item1 != null)
                     {
-                        stack.Push(item);
-                        ops.Push((3, target));  // prepend list
-
-                        // We only need to convert if it's not already the right type
-                        if (!LooksLikeCLVMObject(item))
-                        {
-                            ops.Push((0, null));  // convert
-                        }
+                        Console.WriteLine("left is not a CLVM object");
+                        stack.Add(tuple.Item1);
+                        ops.Add((1, target)); // set left
+                        ops.Add((0, -1)); // convert
                     }
 
                     continue;
                 }
 
-                stack.Push(new CLVMObject(ConvertAtomToBytes(value)));
+                if (value is Object[] list)
+                {
+                    Console.WriteLine("v is a list");
+                    target = stack.Count;
+                    Console.WriteLine($"length of stack is {target}");
+                    stack.Add(new CLVMObject(nullBytes));
+                    Console.WriteLine($"length of list is {list.Length}");
+                    int iteration = 0;
+                    foreach (object item in list)
+                    {
+                        iteration += 1;
+                        
+                        
+                        stack.Add(item);
+                        ops.Add((3, target)); // prepend list
+                        
+                        // We only need to convert if it's not already the right type
+                        if (!LooksLikeCLVMObject(item))
+                        {
+                            Console.WriteLine($"Converting Object {item.GetType()}");
+                            ops.Add((0, -1)); // convert
+                        }
+                    }
+
+                    continue;
+                }
+                
+                Console.WriteLine("converting to bytes");
+                stack.Add(new CLVMObject(ConvertAtomToBytes(value)));
                 continue;
             }
 
-            if (op == 1)  // set left
+            if (op == 1) // set left
             {
-                var left = new CLVMObject(stack.Pop());
-                stack.Push(new CLVMObject(new Tuple<CLVMObject, CLVMObject>(
-                    left, ((Tuple<CLVMObject, CLVMObject>)stack.Peek().Value).Item2)));
+                Console.WriteLine("op1");
+                var leftValue = (CLVMObject)stack[stack.Count-1];
+                stack.RemoveAt(stack.Count-1);
+                var currentPair = ((Tuple<CLVMObject, CLVMObject>)stack[target]);
+                stack[target] = new Tuple<CLVMObject, CLVMObject>(leftValue, currentPair.Item2);
                 continue;
             }
 
-            if (op == 2)  // set right
+            if (op == 2) // set right
             {
-                var right = new CLVMObject(stack.Pop());
-                stack.Push(new CLVMObject(new Tuple<CLVMObject, CLVMObject>(
-                    ((Tuple<CLVMObject, CLVMObject>)stack.Peek().Value).Item1, right)));
+                Console.WriteLine("op2");
+                var rightValue = (CLVMObject)stack[stack.Count-1];
+                stack.RemoveAt(stack.Count-1);
+                var currentPair = ((Tuple<CLVMObject, CLVMObject>)stack[target]);
+                stack[target] = new Tuple<CLVMObject, CLVMObject>(currentPair.Item1, rightValue);
                 continue;
             }
 
-            if (op == 3)  // prepend list
+            if (op == 3) // prepend list
             {
-                stack.Push(new CLVMObject(new Tuple<CLVMObject, CLVMObject>(
-                    new CLVMObject(stack.Pop()), ((Tuple<CLVMObject, CLVMObject>)stack.Peek().Value).Item2)));
+                Console.WriteLine("op3");
+                var item = stack[stack.Count-1];
+                stack.RemoveAt(stack.Count-1);
+                var newValue = new Tuple<object, object>(
+                    item,
+                    stack[target]
+                );
+                stack[target] = new CLVMObject(newValue);
                 continue;
             }
         }
@@ -109,41 +129,51 @@ public static class HelperFunctions
             throw new ArgumentException("Internal error");
         }
 
-        // stack[0] implements the CLVM object protocol and can be wrapped by a SExp
-        return stack.Pop();
+        // stack[0] implements the CLVM object protocol and can be wrapped by an SExp
+        return (CLVMObject)stack[0];
     }
-    
-    
-    public static byte[] ConvertAtomToBytes(object v)
+
+    public static byte[] ConvertAtomToBytes(dynamic? v)
     {
         if (v is byte[] bytes)
         {
+            Console.WriteLine("Atom is bytes");
             return bytes;
         }
+
         if (v is string str)
         {
+            Console.WriteLine("Atom is string");
             return Encoding.UTF8.GetBytes(str);
         }
+
         if (v is int intValue)
         {
+            Console.WriteLine("Atom is Int");
             return BitConverter.GetBytes(intValue);
         }
+
         if (v is null)
         {
+            Console.WriteLine("Atom is null");
             return Array.Empty<byte>();
         }
+
         if (v is IList list && list.Count == 0)
         {
+            Console.WriteLine("Atom is empty list");
             return Array.Empty<byte>();
         }
+
         if (v is IConvertible convertible)
         {
             byte byteValue = convertible.ToByte(System.Globalization.CultureInfo.InvariantCulture);
             return new byte[] { byteValue };
         }
+
         throw new ArgumentException($"Can't cast {v.GetType()} ({v}) to bytes");
     }
-    
+
     public static bool LooksLikeCLVMObject(object o)
     {
         Type type = o.GetType();
@@ -154,11 +184,11 @@ public static class HelperFunctions
 
         foreach (PropertyInfo property in properties)
         {
-            if (property.Name == "atom")
+            if (property.Name == "Atom")
             {
                 hasAtom = true;
             }
-            else if (property.Name == "pair")
+            else if (property.Name == "Pair")
             {
                 hasPair = true;
             }
@@ -168,6 +198,7 @@ public static class HelperFunctions
                 return true;
             }
         }
+
         return false;
     }
 }

--- a/src/clvm-dotnet/HelperFunctions.cs
+++ b/src/clvm-dotnet/HelperFunctions.cs
@@ -150,7 +150,8 @@ public static class HelperFunctions
         if (v is int intValue)
         {
             Console.WriteLine("Atom is Int");
-            return BitConverter.GetBytes(intValue);
+            var s = Casts.IntToBytes(intValue);
+            return s;
         }
 
         if (v is null)

--- a/src/clvm-dotnet/More_Ops.cs
+++ b/src/clvm-dotnet/More_Ops.cs
@@ -128,7 +128,7 @@ public static class More_Ops
          cost += argSize * Costs.ARITH_COST_PER_BYTE;
          return MallocCost(cost, SExp.To(total));
      }
-//     
+    
      // public (BigInteger, SExp) OpDivmod(SExp args)
      // {
      //     BigInteger cost = Costs.DIV_BASE_COST;

--- a/src/clvm-dotnet/More_Ops.cs
+++ b/src/clvm-dotnet/More_Ops.cs
@@ -87,33 +87,32 @@ public static class More_Ops
          return intList;
      }
      
-     // public static IEnumerable<CLVMObject> ArgsAsBools(string opName, SExp args)
-     // {
-     //     foreach (var arg in args.AsIter())
-     //     {
-     //         byte[] v = arg.AsAtom();
-     //         if (v.Length == 0)
-     //         {
-     //             yield return args.False;
-     //         }
-     //         else
-     //         {
-     //             yield return args.True;
-     //         }
-     //     }
-     // }
+     public static IEnumerable<CLVMObject> ArgsAsBools(string opName, SExp args)
+     {
+         foreach (var arg in args.AsIter())
+         {
+             byte[] v = arg.AsAtom();
+             if (v.Length == 0)
+             {
+                 yield return SExp.False;
+             }
+             else
+             {
+                 yield return SExp.True;
+             }
+         }
+     }
      
-     
-//     public static List<CLVMObject> ArgsAsBoolList(string opName, SExp args, int count)
-//     {
-//         List<CLVMObject> boolList = ArgsAsBools(opName, args).ToList();
-//         if (boolList.Count != count)
-//         {
-//             string plural = count != 1 ? "s" : "";
-//             throw new EvalError($"{opName} takes exactly {count} argument{plural}", args);
-//         }
-//         return boolList;
-//     }
+     public static List<CLVMObject> ArgsAsBoolList(string opName, SExp args, int count)
+     {
+         List<CLVMObject> boolList = ArgsAsBools(opName, args).ToList();
+         if (boolList.Count != count)
+         {
+             string plural = count != 1 ? "s" : "";
+             throw new EvalError($"{opName} takes exactly {count} argument{plural}", args);
+         }
+         return boolList;
+     }
 
      public static Tuple<BigInteger,SExp> OpAdd(SExp args)
      {
@@ -443,15 +442,15 @@ public static class More_Ops
 //         return (cost, args.To(result ? args.True : args.False));
 //     }
 //
-//     public (int, SExp) OpAll(dynamic args)
-//     {
-//         List<bool> boolList = ArgsAsBoolList("all", args, 1);
-//         int cost = Costs.BOOL_BASE_COST + boolList.Count * Costs.BOOL_COST_PER_ARG;
-//         bool result = boolList.All(v => v);
-//         return (cost, args.To(result ? args.True : args.False));
-//     }
-//
-//
+     // public (int, SExp) OpAll(dynamic args)
+     // {
+     //     List<bool> boolList = ArgsAsBoolList("all", args, 1);
+     //     int cost = Costs.BOOL_BASE_COST + boolList.Count * Costs.BOOL_COST_PER_ARG;
+     //     bool result = boolList.All(v => v);
+     //     return (cost, args.To(result ? args.True : args.False));
+     // }
+
+
     // public (BigInteger, SExp) OpSoftfork(SExp args)
     // {
     //     if (args.ListLength() < 1)

--- a/src/clvm-dotnet/More_Ops.cs
+++ b/src/clvm-dotnet/More_Ops.cs
@@ -9,10 +9,10 @@ public static class More_Ops
     private const int MALLOC_COST_PER_BYTE = 1;
     private const int SHA256_BASE_COST = 1; // Define other constants as needed.
 
-    public static CostResult MallocCost(BigInteger cost, SExp atom)
+    public static Tuple<BigInteger, SExp>  MallocCost(BigInteger cost, SExp atom)
     {
         BigInteger newCost = cost + atom.AsAtom().Length * MALLOC_COST_PER_BYTE;
-        return new CostResult { Cost = newCost, Atom = atom };
+        return Tuple.Create(newCost,atom);
     }
     
      // public static CostResult OpSha256(SExp args)
@@ -129,22 +129,22 @@ public static class More_Ops
          return MallocCost(cost, args.To(total));
      }
 //     
-//     public (BigInteger, SExp) OpDivmod(SExp args)
-//     {
-//         BigInteger cost = Costs.DIV_BASE_COST;
-//         var (i0, l0) = ArgsAsIntList("divmod", args, 2)[0];
-//         var (i1, l1) = ArgsAsIntList("divmod", args, 2)[1];
-//         if (i1 == 0)
-//         {
-//             throw new EvalError("divmod with 0", args.To(i0));
-//         }
-//         cost += (l0 + l1) * Costs.DIV_COST_PER_BYTE;
-//         BigInteger q = BigInteger.DivRem(i0, i1, out BigInteger r);
-//         SExp q1 = args.To(q);
-//         SExp r1 = args.To(r);
-//         cost += (q1.Atom.Length + r1.Atom.Length) * Costs.MALLOC_COST_PER_BYTE;
-//         return (cost, args.To(new List<SExp> { q1, r1 }));
-//     }
+     public (BigInteger, SExp) OpDivmod(SExp args)
+     {
+         BigInteger cost = Costs.DIV_BASE_COST;
+         var (i0, l0) = ArgsAsIntList("divmod", args, 2)[0];
+         var (i1, l1) = ArgsAsIntList("divmod", args, 2)[1];
+         if (i1 == 0)
+         {
+             throw new EvalError("divmod with 0", args.To(i0));
+         }
+         cost += (l0 + l1) * Costs.DIV_COST_PER_BYTE;
+         BigInteger q = BigInteger.DivRem(i0, i1, out BigInteger r);
+         SExp q1 = args.To(q);
+         SExp r1 = args.To(r);
+         cost += (q1.Atom.Length + r1.Atom.Length) * Costs.MALLOC_COST_PER_BYTE;
+         return (cost, args.To(new List<SExp> { q1, r1 }));
+     }
 //
 //     public (BigInteger, SExp) OpDiv(SExp args)
 //     {
@@ -474,14 +474,5 @@ public static class More_Ops
     //
     //     return (cost, args.False);
     // }
-
-}
-//
-//
-    public class CostResult
-    {
-        public BigInteger Cost { get; set; }
-        public SExp Atom { get; set; }
-    }
 
 }

--- a/src/clvm-dotnet/More_Ops.cs
+++ b/src/clvm-dotnet/More_Ops.cs
@@ -9,101 +9,101 @@ public static class More_Ops
     private const int MALLOC_COST_PER_BYTE = 1;
     private const int SHA256_BASE_COST = 1; // Define other constants as needed.
 
-    public static CostResult MallocCost(int cost, SExp atom)
+    public static CostResult MallocCost(BigInteger cost, SExp atom)
     {
-        int newCost = cost + atom.AsAtom().Length * MALLOC_COST_PER_BYTE;
+        BigInteger newCost = cost + atom.AsAtom().Length * MALLOC_COST_PER_BYTE;
         return new CostResult { Cost = newCost, Atom = atom };
     }
-//     
-//     public static CostResult OpSha256(SExp args)
-//     {
-//         int cost = SHA256_BASE_COST;
-//         int argLen = 0;
-//         using (SHA256 sha256 = SHA256.Create())
-//         {
-//             foreach (SExp arg in args.AsIter())
-//             {
-//                 byte[] atom = arg.AsAtom();
-//                 if (atom == null)
-//                 {
-//                     throw new EvalError("sha256 on list", arg);
-//                 }
-//                 argLen += atom.Length;
-//                 cost += Costs.SHA256_COST_PER_ARG;
-//                 sha256.TransformBlock(atom, 0, atom.Length, null, 0);
-//             }
-//
-//             sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
-//             byte[] result = sha256.Hash;
-//             cost += argLen * Costs.SHA256_COST_PER_BYTE;
-//
-//             return new CostResult { Cost = cost, Atom = args.to(result) };
-//         }
-//     }
-//     
-//     public static IEnumerable<(int, int)> ArgsAsInts(string opName, SExp args)
-//     {
-//         foreach (SExp arg in args.AsIter())
-//         {
-//             if (arg.Pair != null)
-//             {
-//                 throw new EvalError($"{opName} requires int args", arg);
-//             }
-//
-//             int intValue = arg.AsInt();
-//             int atomLength = arg.AsAtom().Length;
-//
-//             yield return (intValue, atomLength);
-//         }
-//     }
-//     
-//     public static IEnumerable<int> ArgsAsInt32(string opName, SExp args)
-//     {
-//         foreach (SExp arg in args.AsIter())
-//         {
-//             if (arg != null )
-//             {
-//                 throw new EvalError($"{opName} requires int32 args", arg);
-//             }
-//
-//             if (arg.AsAtom().Length > 4)
-//             {
-//                 throw new EvalError($"{opName} requires int32 args (with no leading zeros)", arg);
-//             }
-//
-//             yield return arg.AsInt();
-//         }
-//     }
-//     
-//     public static List<BigInteger> ArgsAsIntList(string opName, dynamic args, int count)
-//     {
-//         List<BigInteger> intList = new List<BigInteger>(ArgsAsInts(opName, args));
-//         if (intList.Count != count)
-//         {
-//             string plural = count != 1 ? "s" : "";
-//             throw new EvalError($"{opName} takes exactly {count} argument{plural}", args);
-//         }
-//         return intList;
-//     }
-//     
-//     public static IEnumerable<CLVMObject> ArgsAsBools(string opName, SExp args)
-//     {
-//         foreach (var arg in args.AsIter())
-//         {
-//             byte[] v = arg.AsAtom();
-//             if (v.Length == 0)
-//             {
-//                 yield return args.False;
-//             }
-//             else
-//             {
-//                 yield return args.True;
-//             }
-//         }
-//     }
-//     
-//     public static Tuple<BigInteger, SExp> MallocCost(BigInteger cost, SExp atom) => (cost + atom.Atom.Length * Costs.MALLOC_COST_PER_BYTE = 10, atom);
-//
+    
+     // public static CostResult OpSha256(SExp args)
+     // {
+     //     int cost = SHA256_BASE_COST;
+     //     int argLen = 0;
+     //     using (SHA256 sha256 = SHA256.Create())
+     //     {
+     //         foreach (SExp arg in args.AsIter())
+     //         {
+     //             byte[] atom = arg.AsAtom();
+     //             if (atom == null)
+     //             {
+     //                 throw new EvalError("sha256 on list", arg);
+     //             }
+     //             argLen += atom.Length;
+     //             cost += Costs.SHA256_COST_PER_ARG;
+     //             sha256.TransformBlock(atom, 0, atom.Length, null, 0);
+     //         }
+     //
+     //         sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+     //         byte[] result = sha256.Hash;
+     //         cost += argLen * Costs.SHA256_COST_PER_BYTE;
+     //
+     //         return new CostResult { Cost = cost, Atom = args.AsAtom(result) };
+     //     }
+     // }
+     
+     
+     public static IEnumerable<(BigInteger, int)> ArgsAsInts(string opName, SExp args)
+     {
+         foreach (SExp arg in args.AsIter())
+         {
+             if (arg.Pair != null)
+             {
+                 throw new EvalError($"{opName} requires int args", arg);
+             }
+
+             BigInteger intValue = arg.AsInt();
+             int atomLength = arg.AsAtom().Length;
+
+             yield return (intValue, atomLength);
+         }
+     }
+     
+     public static IEnumerable<BigInteger> ArgsAsInt32(string opName, SExp args)
+     {
+         foreach (SExp arg in args.AsIter())
+         {
+             if (arg != null )
+             {
+                 throw new EvalError($"{opName} requires int32 args", arg);
+             }
+
+             if (arg.AsAtom().Length > 4)
+             {
+                 throw new EvalError($"{opName} requires int32 args (with no leading zeros)", arg);
+             }
+
+             yield return arg.AsInt();
+         }
+     }
+     
+     public static List<BigInteger> ArgsAsIntList(string opName, dynamic args, int count)
+     {
+         List<BigInteger> intList = new List<BigInteger>(ArgsAsInts(opName, args));
+         if (intList.Count != count)
+         {
+             string plural = count != 1 ? "s" : "";
+             throw new EvalError($"{opName} takes exactly {count} argument{plural}", args);
+         }
+         return intList;
+     }
+     
+     // public static IEnumerable<CLVMObject> ArgsAsBools(string opName, SExp args)
+     // {
+     //     foreach (var arg in args.AsIter())
+     //     {
+     //         byte[] v = arg.AsAtom();
+     //         if (v.Length == 0)
+     //         {
+     //             yield return args.False;
+     //         }
+     //         else
+     //         {
+     //             yield return args.True;
+     //         }
+     //     }
+     // }
+     
+     
 //     public static List<CLVMObject> ArgsAsBoolList(string opName, SExp args, int count)
 //     {
 //         List<CLVMObject> boolList = ArgsAsBools(opName, args).ToList();
@@ -114,21 +114,21 @@ public static class More_Ops
 //         }
 //         return boolList;
 //     }
-//
-//     public static Tuple<BigInteger,SExp > OpAdd(SExp args)
-//     {
-//         BigInteger total = 0;
-//         BigInteger cost = Costs.ARITH_BASE_COST;
-//         BigInteger argSize = 0;
-//         foreach ((int r, int l) in ArgsAsInts("+", args))
-//         {
-//             total += r;
-//             argSize += l;
-//             cost += Costs.ARITH_COST_PER_ARG;
-//         }
-//         cost += argSize * Costs.ARITH_COST_PER_BYTE;
-//         return MallocCost(cost, args.To(total));
-//     }
+
+     public static Tuple<BigInteger,SExp> OpAdd(SExp args)
+     {
+         BigInteger total = 0;
+         BigInteger cost = Costs.ARITH_BASE_COST;
+         BigInteger argSize = 0;
+         foreach ((BigInteger r, BigInteger l) in ArgsAsInts("+", args))
+         {
+             total += r;
+             argSize += l;
+             cost += Costs.ARITH_COST_PER_ARG;
+         }
+         cost += argSize * Costs.ARITH_COST_PER_BYTE;
+         return MallocCost(cost, args.To(total));
+     }
 //     
 //     public (BigInteger, SExp) OpDivmod(SExp args)
 //     {
@@ -452,36 +452,36 @@ public static class More_Ops
 //     }
 //
 //
-//     public (BigInteger, SExp) OpSoftfork(SExp args)
-//     {
-//         if (args.ListLength() < 1)
-//         {
-//             throw new EvalError("softfork takes at least 1 argument", args);
-//         }
-//
-//         SExp a = args.First();
-//     
-//         if (a.Pair != null)
-//         {
-//             throw new EvalError("softfork requires int args", a);
-//         }
-//
-//         var cost = a.AsInt();
-//     
-//         if (cost < 1)
-//         {
-//             throw new EvalError("cost must be > 0", args);
-//         }
-//
-//         return (cost, args.False);
-//     }
-//
-// }
+    // public (BigInteger, SExp) OpSoftfork(SExp args)
+    // {
+    //     if (args.ListLength() < 1)
+    //     {
+    //         throw new EvalError("softfork takes at least 1 argument", args);
+    //     }
+    //
+    //     SExp a = args.First();
+    //
+    //     if (a.Pair != null)
+    //     {
+    //         throw new EvalError("softfork requires int args", a);
+    //     }
+    //
+    //     var cost = a.AsInt();
+    //
+    //     if (cost < 1)
+    //     {
+    //         throw new EvalError("cost must be > 0", args);
+    //     }
+    //
+    //     return (cost, args.False);
+    // }
+
+}
 //
 //
     public class CostResult
     {
-        public int Cost { get; set; }
+        public BigInteger Cost { get; set; }
         public SExp Atom { get; set; }
     }
 

--- a/src/clvm-dotnet/More_Ops.cs
+++ b/src/clvm-dotnet/More_Ops.cs
@@ -126,25 +126,25 @@ public static class More_Ops
              cost += Costs.ARITH_COST_PER_ARG;
          }
          cost += argSize * Costs.ARITH_COST_PER_BYTE;
-         return MallocCost(cost, args.To(total));
+         return MallocCost(cost, SExp.To(total));
      }
 //     
-     public (BigInteger, SExp) OpDivmod(SExp args)
-     {
-         BigInteger cost = Costs.DIV_BASE_COST;
-         var (i0, l0) = ArgsAsIntList("divmod", args, 2)[0];
-         var (i1, l1) = ArgsAsIntList("divmod", args, 2)[1];
-         if (i1 == 0)
-         {
-             throw new EvalError("divmod with 0", args.To(i0));
-         }
-         cost += (l0 + l1) * Costs.DIV_COST_PER_BYTE;
-         BigInteger q = BigInteger.DivRem(i0, i1, out BigInteger r);
-         SExp q1 = args.To(q);
-         SExp r1 = args.To(r);
-         cost += (q1.Atom.Length + r1.Atom.Length) * Costs.MALLOC_COST_PER_BYTE;
-         return (cost, args.To(new List<SExp> { q1, r1 }));
-     }
+     // public (BigInteger, SExp) OpDivmod(SExp args)
+     // {
+     //     BigInteger cost = Costs.DIV_BASE_COST;
+     //     var (i0, l0) = ArgsAsIntList("divmod", args, 2)[0];
+     //     var (i1, l1) = ArgsAsIntList("divmod", args, 2)[1];
+     //     if (i1 == 0)
+     //     {
+     //         throw new EvalError("divmod with 0", args.To(i0));
+     //     }
+     //     cost += (l0 + l1) * Costs.DIV_COST_PER_BYTE;
+     //     BigInteger q = BigInteger.DivRem(i0, i1, out BigInteger r);
+     //     SExp q1 = args.To(q);
+     //     SExp r1 = args.To(r);
+     //     cost += (q1.Atom.Length + r1.Atom.Length) * Costs.MALLOC_COST_PER_BYTE;
+     //     return (cost, args.To(new List<SExp> { q1, r1 }));
+     // }
 //
 //     public (BigInteger, SExp) OpDiv(SExp args)
 //     {

--- a/src/clvm-dotnet/SExp.cs
+++ b/src/clvm-dotnet/SExp.cs
@@ -91,7 +91,7 @@ public class SExp
         return size;
     }
     
-    public static SExp To(dynamic v)
+    public SExp To(dynamic v)
     {
         if (v is SExp se)
         {

--- a/src/clvm-dotnet/SExp.cs
+++ b/src/clvm-dotnet/SExp.cs
@@ -31,15 +31,20 @@ public class SExp
         Pair = obj.Pair;
     }
 
+    public SExp()
+    {
+        
+    }
+
     public Tuple<SExp, SExp>? AsPair()
     {
-        var pair = this.Pair;
-        if (pair == null)
+        if (Pair == null)
         {
             return null;
         }
-
-        return Tuple.Create(new SExp(pair?.Item1), new SExp(pair?.Item2));
+        var left = Pair.Item1 is SExp ? Pair.Item1 : new SExp (Pair.Item1);
+        var right = Pair.Item2 is SExp ? Pair.Item2 : new SExp(Pair.Item2);
+        return Tuple.Create<SExp,SExp>(left,right);
     }
 
     public byte[]? AsAtom()

--- a/src/clvm-dotnet/SExp.cs
+++ b/src/clvm-dotnet/SExp.cs
@@ -91,18 +91,21 @@ public class SExp
         return size;
     }
     
-    public SExp To(dynamic v)
+    public static SExp To(dynamic v)
     {
         if (v is SExp se)
         {
+            Console.WriteLine("looks like sexp type to()");
             return se;
         }
 
         if (HelperFunctions.LooksLikeCLVMObject(v))
         {
+            Console.WriteLine("clvm object");
             return new SExp(v);
         }
 
+        Console.WriteLine("looks like sexp type to()");
         return new SExp(HelperFunctions.ToSexpType(v));
     }
     
@@ -155,9 +158,11 @@ public class SExp
         var stackList = stack.ToArray();
         Stack<Tuple<int, int>> ops = new Stack<Tuple<int, int>>();
         ops.Push(new Tuple<int, int>(0, -1)); // convert
-
+        int opIteration = 0;
         while (ops.Count > 0)
         {
+            opIteration += 1;
+            Console.WriteLine($"op iteration: {opIteration}");
             Tuple<int, int> opTarget = ops.Pop();
             int op = opTarget.Item1;
             int target = opTarget.Item2;
@@ -165,6 +170,7 @@ public class SExp
             // Convert value
             if (op == 0)
             {
+                Console.Write("op0");
                 if (HelperFunctions.LooksLikeCLVMObject(stack.Peek()))
                 {
                     continue;
@@ -280,14 +286,17 @@ public class SExp
         }
         else if (v is string str)
         {
+            Console.WriteLine("is string");
             return Encoding.UTF8.GetBytes(str);
         }
         else if (v is int intValue)
         {
+            Console.WriteLine("is int");
             return BitConverter.GetBytes(intValue);
         }
         else if (v is null)
         {
+            Console.WriteLine("is null");
             return new byte[0];
         }
         else if (v is List<object> list)

--- a/src/clvm-dotnet/SExp.cs
+++ b/src/clvm-dotnet/SExp.cs
@@ -7,7 +7,7 @@ using clvm_dotnet;
 //  SExp provides higher level API on top of any object implementing the CLVM
 //  object protocol.
 //  The tree of values is not a tree of SExp objects, it's a tree of CLVMObject
-//  like objects. SExp simply wraps them to privide a uniform view of any
+//  like objects. SExp simply wraps them to provide a uniform view of any
 //  underlying conforming tree structure.
 //
 //  The CLVM object protocol (concept) exposes two attributes:

--- a/src/clvm-dotnet/SExp.cs
+++ b/src/clvm-dotnet/SExp.cs
@@ -40,10 +40,14 @@ public class SExp
     {
         if (Pair == null)
         {
+            Console.WriteLine("self.pair is null");
             return null;
         }
         var left = Pair.Item1 is SExp ? Pair.Item1 : new SExp (Pair.Item1);
         var right = Pair.Item2 is SExp ? Pair.Item2 : new SExp(Pair.Item2);
+        
+        Console.WriteLine($"type of pair[0]: {left}");
+        Console.WriteLine($"type of pair[1]: {right}");
         return Tuple.Create<SExp,SExp>(left,right);
     }
 
@@ -98,9 +102,11 @@ public class SExp
     
     public static SExp To(dynamic? v)
     {
+        Console.WriteLine("\nnot sure why this is being called");
+        
         if (v is SExp se)
         {
-            Console.WriteLine("looks like sexp type to()");
+            Console.WriteLine("instance of sexp");
             return se;
         }
 
@@ -110,7 +116,7 @@ public class SExp
             return new SExp(v);
         }
 
-        Console.WriteLine("looks like sexp type to()");
+        Console.WriteLine($"looks like sexp type to() {v}");
         return new SExp(HelperFunctions.ToSexpType(v));
     }
     
@@ -159,50 +165,48 @@ public class SExp
 
     public bool Equals(dynamic other)
     {
-        return true;
+        try
+        {
+            var thisob = this;
+            var otherObj = SExp.To(other);
+            Stack<(SExp, SExp)> toCompareStack = new Stack<(SExp, SExp)>();
+            toCompareStack.Push((this, otherObj));
+            
+            
+
+            while (toCompareStack.Count > 0)
+            {
+                var (s1,s2)  = toCompareStack.Pop();
+                var p1 = s1.AsPair();
+
+                if (p1 != null)
+                {
+                    var p2 = s2.AsPair();
+
+                    if (p2 != null)
+                    {
+                        toCompareStack.Push((p1.Item1, p2.Item1));
+                        toCompareStack.Push((p1.Item2, p2.Item2));
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else if (s2.AsPair() != null || !s1.AsAtom().SequenceEqual(s2.AsAtom()))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
     }
 
-    // Console.WriteLine("eq is being called");
-    //     try
-    //     {
-    //         other = SExp.To(other);
-    //         Stack<Tuple<dynamic, dynamic>> toCompareStack = new Stack<Tuple<dym, CastableType>>();
-    //         toCompareStack.Push(new Tuple<YourClass, CastableType>(this, other));
-    //
-    //         while (toCompareStack.Count > 0)
-    //         {
-    //             Tuple<YourClass, CastableType> pair = toCompareStack.Pop();
-    //             YourClass s1 = pair.Item1;
-    //             CastableType s2 = pair.Item2;
-    //
-    //             Tuple<YourClass, YourClass> p1 = s1.AsPair();
-    //             if (p1 != null)
-    //             {
-    //                 Tuple<CastableType, CastableType> p2 = s2.AsPair();
-    //                 if (p2 != null)
-    //                 {
-    //                     toCompareStack.Push(new Tuple<YourClass, CastableType>(p1.Item1, p2.Item1));
-    //                     toCompareStack.Push(new Tuple<YourClass, CastableType>(p1.Item2, p2.Item2));
-    //                 }
-    //                 else
-    //                 {
-    //                     return false;
-    //                 }
-    //             }
-    //             else if (s2.AsPair() != null || !s1.AsAtom().Equals(s2.AsAtom()))
-    //             {
-    //                 return false;
-    //             }
-    //         }
-    //
-    //         return true;
-    //     }
-    //     catch (ArgumentException)
-    //     {
-    //         return false;
-    //     }
-    // }
-    
     
     public SExp ToSexpType(dynamic v)
     {

--- a/src/clvm-dotnet/SExp.cs
+++ b/src/clvm-dotnet/SExp.cs
@@ -2,8 +2,6 @@ using System.Numerics;
 using System.Text;
 using clvm_dotnet;
 
-
-/// <summary>
 //  SExp provides higher level API on top of any object implementing the CLVM
 //  object protocol.
 //  The tree of values is not a tree of SExp objects, it's a tree of CLVMObject
@@ -15,13 +13,11 @@ using clvm_dotnet;
 //  2. "pair" which is either None or a tuple of exactly two elements. Both
 // elements implementing the CLVM object protocol.
 // Exactly one of "atom" and "pair" must be None.
-/// </summary>
 public class SExp
 {
      public static CLVMObject True { get; } = new CLVMObject { Atom = new byte[] { 0x01 } };
      public static CLVMObject False { get; } = new CLVMObject();
      public static CLVMObject NULL { get; } = null;
-
      public byte[]? Atom { get; set; }
     public Tuple<dynamic, dynamic>? Pair { get; set; }
 
@@ -33,21 +29,16 @@ public class SExp
 
     public SExp()
     {
-        
     }
 
     public Tuple<SExp, SExp>? AsPair()
     {
         if (Pair == null)
         {
-            Console.WriteLine("self.pair is null");
             return null;
         }
         var left = Pair.Item1 is SExp ? Pair.Item1 : new SExp (Pair.Item1);
         var right = Pair.Item2 is SExp ? Pair.Item2 : new SExp(Pair.Item2);
-        
-        Console.WriteLine($"type of pair[0]: {left}");
-        Console.WriteLine($"type of pair[1]: {right}");
         return Tuple.Create<SExp,SExp>(left,right);
     }
 
@@ -102,21 +93,16 @@ public class SExp
     
     public static SExp To(dynamic? v)
     {
-        Console.WriteLine("\nnot sure why this is being called");
-        
         if (v is SExp se)
         {
-            Console.WriteLine("instance of sexp");
             return se;
         }
 
         if (HelperFunctions.LooksLikeCLVMObject(v))
         {
-            Console.WriteLine("clvm object");
             return new SExp(v);
         }
-
-        Console.WriteLine($"looks like sexp type to() {v}");
+        
         return new SExp(HelperFunctions.ToSexpType(v));
     }
     
@@ -172,8 +158,6 @@ public class SExp
             Stack<(SExp, SExp)> toCompareStack = new Stack<(SExp, SExp)>();
             toCompareStack.Push((this, otherObj));
             
-            
-
             while (toCompareStack.Count > 0)
             {
                 var (s1,s2)  = toCompareStack.Pop();
@@ -206,7 +190,6 @@ public class SExp
             return false;
         }
     }
-
     
     public SExp ToSexpType(dynamic v)
     {
@@ -218,7 +201,6 @@ public class SExp
         while (ops.Count > 0)
         {
             opIteration += 1;
-            Console.WriteLine($"op iteration: {opIteration}");
             Tuple<int, int> opTarget = ops.Pop();
             int op = opTarget.Item1;
             int target = opTarget.Item2;
@@ -226,14 +208,11 @@ public class SExp
             // Convert value
             if (op == 0)
             {
-                Console.Write("op0");
                 if (HelperFunctions.LooksLikeCLVMObject(stack.Peek()))
                 {
                     continue;
                 }
-
                 dynamic? value = stack.Pop();
-
                 if (value is Tuple<dynamic, dynamic> tupleValue)
                 {
                     object left = tupleValue.Item1;
@@ -263,7 +242,6 @@ public class SExp
                             ops.Push(Tuple.Create(1, target)); // set left
                             ops.Push(Tuple.Create(0, -1)); // convert
                         }
-
                         continue;
                     }
                 }
@@ -283,17 +261,14 @@ public class SExp
                             ops.Push(Tuple.Create(0, -1)); // convert
                         }
                     }
-
                     continue;
                 }
-
                 stack.Push(new CLVMObject(ConvertAtomToBytes(value)));
                 continue;
             }
 
             if (op == 1) // set left
             {
-                
                 if (stackList[target] is CLVMObject clvmObject)
                 {
                     clvmObject.Pair = new (stack.Pop(), clvmObject.Pair.Item2);
@@ -309,7 +284,6 @@ public class SExp
 
                     clvmObject.Pair = new(clvmObject.Pair.Item1, new CLVMObject(stack.Pop()));
                 }
-
                 continue;
             }
 
@@ -319,7 +293,6 @@ public class SExp
                 {
                     clvmObject.Pair = new (stack.Pop(), clvmObject.Pair);
                 }
-
                 continue;
             }
         }
@@ -342,17 +315,14 @@ public class SExp
         }
         else if (v is string str)
         {
-            Console.WriteLine("is string");
             return Encoding.UTF8.GetBytes(str);
         }
         else if (v is int intValue)
         {
-            Console.WriteLine("is int");
             return BitConverter.GetBytes(intValue);
         }
         else if (v is null)
         {
-            Console.WriteLine("is null");
             return new byte[0];
         }
         else if (v is List<object> list)
@@ -362,10 +332,8 @@ public class SExp
             {
                 result.AddRange(ConvertAtomToBytes(item));
             }
-
             return result.ToArray();
         }
-
         throw new ArgumentException($"Can't cast {v.GetType()} ({v}) to bytes");
     }
 }

--- a/src/clvm-dotnet/SExp.cs
+++ b/src/clvm-dotnet/SExp.cs
@@ -25,7 +25,7 @@ public class SExp
      public byte[]? Atom { get; set; }
     public Tuple<dynamic, dynamic>? Pair { get; set; }
 
-    public SExp(CLVMObject obj)
+    public SExp(CLVMObject? obj)
     {
         Atom = obj.Atom;
         Pair = obj.Pair;
@@ -96,7 +96,7 @@ public class SExp
         return size;
     }
     
-    public static SExp To(dynamic v)
+    public static SExp To(dynamic? v)
     {
         if (v is SExp se)
         {
@@ -157,9 +157,56 @@ public class SExp
         return BitConverter.ToString(AsBin()).Replace("-", "");
     }
 
+    public bool Equals(dynamic other)
+    {
+        return true;
+    }
+
+    // Console.WriteLine("eq is being called");
+    //     try
+    //     {
+    //         other = SExp.To(other);
+    //         Stack<Tuple<dynamic, dynamic>> toCompareStack = new Stack<Tuple<dym, CastableType>>();
+    //         toCompareStack.Push(new Tuple<YourClass, CastableType>(this, other));
+    //
+    //         while (toCompareStack.Count > 0)
+    //         {
+    //             Tuple<YourClass, CastableType> pair = toCompareStack.Pop();
+    //             YourClass s1 = pair.Item1;
+    //             CastableType s2 = pair.Item2;
+    //
+    //             Tuple<YourClass, YourClass> p1 = s1.AsPair();
+    //             if (p1 != null)
+    //             {
+    //                 Tuple<CastableType, CastableType> p2 = s2.AsPair();
+    //                 if (p2 != null)
+    //                 {
+    //                     toCompareStack.Push(new Tuple<YourClass, CastableType>(p1.Item1, p2.Item1));
+    //                     toCompareStack.Push(new Tuple<YourClass, CastableType>(p1.Item2, p2.Item2));
+    //                 }
+    //                 else
+    //                 {
+    //                     return false;
+    //                 }
+    //             }
+    //             else if (s2.AsPair() != null || !s1.AsAtom().Equals(s2.AsAtom()))
+    //             {
+    //                 return false;
+    //             }
+    //         }
+    //
+    //         return true;
+    //     }
+    //     catch (ArgumentException)
+    //     {
+    //         return false;
+    //     }
+    // }
+    
+    
     public SExp ToSexpType(dynamic v)
     {
-        Stack<dynamic> stack = new Stack<dynamic>();
+        Stack<dynamic?> stack = new Stack<dynamic?>();
         var stackList = stack.ToArray();
         Stack<Tuple<int, int>> ops = new Stack<Tuple<int, int>>();
         ops.Push(new Tuple<int, int>(0, -1)); // convert
@@ -181,7 +228,7 @@ public class SExp
                     continue;
                 }
 
-                dynamic value = stack.Pop();
+                dynamic? value = stack.Pop();
 
                 if (value is Tuple<dynamic, dynamic> tupleValue)
                 {


### PR DESCRIPTION
Hey @MichaelTaylor3D / @dkackman - thought I'd tag both, and anyone else who may be able to help!

I've created this PR for us all to collaborate and see if we can iron out the remaining bits of the clvm that needs to be ported to get a working version of clvm in dotnet. I've merged everything that I had migrated previously. 

I've prioritised what's left to do to get the port working.

# Code left to port
The following is a list of what code is left to port to get a working clvm in dotnet.

## SExp (https://github.com/Chia-Network/clvm/blob/main/clvm/SExp.py)
- [x] SExp equality _eq_ - https://github.com/Chia-Network/clvm/blob/main/clvm/SExp.py#L209 (blocks a few tests) 
- [x] Python allows for Classes to have both instance methods and class methods with the same name. e.g. 
https://github.com/Chia-Network/clvm/blob/main/clvm/SExp.py#L175C1-L175C1 (Class Method & Instance methods) A new Instance method is required to unblock More_Options.

##  MoreOps - (https://github.com/Chia-Network/clvm/blob/main/clvm/more_ops.py)
- [x]  ArgsAsBoolList() 
- [x]  ArgsAsBools() 
- [ ]  OpPubkeyForExp() | BLS Library is needed for this?   (this should be unblocked by the work @dkackman is doing).
- [ ]  OpSha256()
- [ ]  OpSoftfork() 
- [ ]  OpAll() 
- [ ]  OpAny() 
- [ ]  OpNot() 
- [ ]  OpLognot() 
- [ ]  OpLogxor() 
- [ ]  OpLogior() 
- [ ]  OpLogand() 
- [ ]  BinopReduction() 
- [ ]  OpLsh() 
- [ ]  OpAsh()
- [ ]  OpConcat() 
- [ ]  OpSubstr() 
- [ ]  OpStrlen() 
- [ ]  OpPointAdd() 
- [ ]  OpGrBytes() 
- [ ]  OpGr() 
- [ ]  OpDiv() 
- [ ]  OpDivmod() 
- [ ]  OpAdd() 

##  Program (https://github.com/Chia-Network/clvm/blob/main/clvm/run_program.py)
- [ ] traverse_path
- [ ] swap_op
- [ ] cons_op
- [ ] eval_op
- [ ] apply_op

# Unit Tests
## CastsTests
- [x] IntFromBytes 
- [x] IntToBytes  
- [x] LimbsForInt

## SExpTests
- [x] test_case_1 
- [x] TestWrapSExp 
- [x] TestListConversions
- [x] TestStringConversions
- [x]  int_conversions 
- [x]  TestNoneBytesConversions 
- [x]  empty_list_conversions

## SerializeTests
- [x] test_deserialize_empty 
- [x] test_deserialize_truncated_size
- [x] test_deserialize_truncated_blob
- [ ] test_deserialize_large_blob - @KevinOnFrontEnd 
- [x]  test_short_lists 
- [ ]  test_cons_box
- [ ] test_long_blobs
- [ ] test_very_long_blobs
- [ ] test_very_deep_tree
- [x]  check_serde
- [x]  test_zero
- [x]  test_empty
- [x]  test_empty_string
- [x]  test_single_bytes
- [x] test_blob_limit - #NOT NEEDED# - dotnet won't let you create a byte of 0x400000001 as the python version does.





## BitTests (run_program_tests.py) - check most significant bits
- [x] test_msb_mask

## OperatorTests
- [ ]  test_plus
- [ ]  test_unknown_op
- [ ]  test_unknown_ops_last_bits
- [ ]  unknown_handler   

## OperatorDictTest
- [ ] test_operatordict_constructor

## BLSTests
- [ ] test_stream

## AsPythonTests
- [ ] test_null
- [ ] test_embedded_tuples
- [ ] test_single_bytes
- [ ] test_short_lists
- [ ] test_int
- [ ] test_none
- [ ] test_empty_list
- [ ] test_list_of_one
- [ ] test_g1element
- [ ] test_complex
- [ ] test_listp
- [ ] test_nullp
- [ ] test_constants
- [ ] test_list_len
- [ ] test_list_len_atom
- [ ] test_as_int
- [ ] test_cons
- [ ] test_string
- [ ] test_deep_recursion
- [ ] test_long_linked_list
- [ ] test_long_list
- [ ] test_invalid_type
- [ ] test_invalid_tuple
- [ ] test_clvm_object_tuple
- [ ] test_first
- [ ] test_rest
- [ ] test_as_iter
- [ ] test_eq
- [ ] test_eq_tree
- [ ] test_str
- [ ] test_repr
  

