### PR TITLE
Add clvm tools IRReader & IRWriter

### DIFF
--- a/CLVMDotNet/CLVMDotNet.Tools.Tests/CLVMDotNet.Tools.Tests.csproj
+++ b/CLVMDotNet/CLVMDotNet.Tools.Tests/CLVMDotNet.Tools.Tests.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/CLVMDotNet/CLVMDotNet.Tools.Tests/CLVMDotNet.Tools.Tests.csproj
+++ b/CLVMDotNet/CLVMDotNet.Tools.Tests/CLVMDotNet.Tools.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\CLVMDotNet.Tools\CLVMDotNet.Tools.csproj" />
+      <ProjectReference Include="..\src\CLVMDotNet.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/CLVMDotNet/CLVMDotNet.Tools.Tests/IRReader/ReadIRTests.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools.Tests/IRReader/ReadIRTests.cs
@@ -1,15 +1,17 @@
 using Xunit;
+using x = CLVMDotNet.Tools.IR;
 
-namespace CLVMDotNet.Tools.Tests;
+namespace CLVMDotNet.Tools.Tests.IRReader;
 
-public class IRReaderTests
+[Trait("IRReader", "ReadIR")]
+public class ReadIRTests
 {
     [Fact]
     public void Tokenize_comments()
     {
         var script_source = "(equal 7 (+ 5 ;foo bar\n   2))";
         var expected_output = "(equal 7 (+ 5 2))";
-        var t = Tokenizer.ReadIR(script_source);
+        var t = x.IRReader.ReadIR(script_source);
         // s = Tokewrite_ir(t)
         // Assert.Equal(s, expected_output);
     }

--- a/CLVMDotNet/CLVMDotNet.Tools.Tests/IRReader/ReadIRTests.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools.Tests/IRReader/ReadIRTests.cs
@@ -1,5 +1,6 @@
 using Xunit;
 using x = CLVMDotNet.Tools.IR;
+using comm = CLVMDotNet.Tools;
 
 namespace CLVMDotNet.Tools.Tests.IRReader;
 
@@ -7,12 +8,18 @@ namespace CLVMDotNet.Tools.Tests.IRReader;
 public class ReadIRTests
 {
     [Fact]
-    public void Tokenize_comments()
+    public void IRReader_ignores_comments()
     {
         var script_source = "(equal 7 (+ 5 ;foo bar\n   2))";
         var expected_output = "(equal 7 (+ 5 2))";
         var t = x.IRReader.ReadIR(script_source);
-        // s = Tokewrite_ir(t)
-        // Assert.Equal(s, expected_output);
+        var s = x.IRReader.ReadIR(expected_output);
+        var areEqual = s.Equals(t);
+        
+        //s will never equal to t because the sexp tree will hold different 
+        //character offsets from source.
+        Assert.False(areEqual);
+        
+        //TODO: Write IRWriter  class
     }
 }

--- a/CLVMDotNet/CLVMDotNet.Tools.Tests/IRReader/TokenStreamTests.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools.Tests/IRReader/TokenStreamTests.cs
@@ -1,0 +1,23 @@
+using Xunit;
+using x = CLVMDotNet.Tools.IR;
+
+namespace CLVMDotNet.Tools.Tests.IRReader;
+
+[Trait("IRReader", value:"TokenStream")]
+public class TokenStreamTests
+{
+    [Theory]
+    [InlineData("(equal 7 (+ 5 ;foo bar\n   2))", 9)]
+    [InlineData("(equal 7 (+ 5 ;foo bar\n \n\n\n \n\n\r  2))", 9)]
+    [InlineData("(equal 7 (+ 5 ;foo bar\n \n\n\n \n\n\r  8))", 9)]
+    [InlineData("(equal 7 (+ 5 (+ 1 5)))", 13)]
+    [InlineData("(- 5 4)", 5)]
+    [InlineData("(- 5 (- 6 (- 5 (- 5 6))))", 17)]
+    public void TokenStreamReader_matches_python_stream_length(string input, int lengthOfStream)
+    {
+        var stream = x.IRReader.TokenStream(input);
+        var count = stream.Count();
+        Assert.Equal(lengthOfStream, count);
+    }
+    
+}

--- a/CLVMDotNet/CLVMDotNet.Tools.Tests/IRReaderTests.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools.Tests/IRReaderTests.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace CLVMDotNet.Tools.Tests;
+
+public class IRReaderTests
+{
+    [Fact]
+    public void Tokenize_comments()
+    {
+        var script_source = "(equal 7 (+ 5 ;foo bar\n   2))";
+        var expected_output = "(equal 7 (+ 5 2))";
+        var t = Tokenizer.ReadIR(script_source);
+        // s = Tokewrite_ir(t)
+        // Assert.Equal(s, expected_output);
+    }
+}

--- a/CLVMDotNet/CLVMDotNet.Tools.Tests/IRWriter/WriteIRTests.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools.Tests/IRWriter/WriteIRTests.cs
@@ -9,13 +9,16 @@ public class IRWriterTests
 {
     [Theory]
     [InlineData("100")]
-    //[InlineData("0x0100")]
-    // [InlineData("0x100")]
-    // [InlineData("\"100\"")]
-    // [InlineData("the quick brown fox jumps over the lazy dogs")]
-    // [InlineData("(the quick brown fox jumps over the lazy dogs)")]
-    // [InlineData("foo")]
-    // [InlineData("(100 0x0100)")]
+    [InlineData("0x0100")]
+    [InlineData("0x100")]
+    [InlineData("\"100\"")]
+    [InlineData("the quick brown fox jumps over the lazy dogs")]
+    [InlineData("(the quick brown fox jumps over the lazy dogs)")]
+    [InlineData("foo")]
+    [InlineData("(100 0x0100)")]
+    [InlineData("(c (quote 100) (c (quote \"foo\") (quote ())))")]
+    [InlineData("(c . foo)")]
+    [InlineData("(a b c de f g h i . j)")]
     public void WriterTests(string sexpText)
     {
         var irSexp = x.IRReader.ReadIR(sexpText);

--- a/CLVMDotNet/CLVMDotNet.Tools.Tests/IRWriter/WriteIRTests.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools.Tests/IRWriter/WriteIRTests.cs
@@ -1,0 +1,28 @@
+using Xunit;
+using x = CLVMDotNet.Tools.IR;
+using comm = CLVMDotNet.Tools;
+
+namespace CLVMDotNet.Tools.Tests.IRWriter;
+
+[Trait("IRWriter", "WriteIr")]
+public class IRWriterTests
+{
+    [Theory]
+    [InlineData("100")]
+    //[InlineData("0x0100")]
+    // [InlineData("0x100")]
+    // [InlineData("\"100\"")]
+    // [InlineData("the quick brown fox jumps over the lazy dogs")]
+    // [InlineData("(the quick brown fox jumps over the lazy dogs)")]
+    // [InlineData("foo")]
+    // [InlineData("(100 0x0100)")]
+    public void WriterTests(string sexpText)
+    {
+        var irSexp = x.IRReader.ReadIR(sexpText);
+        var sexpTextNormalized = x.IRWRiter.WriteIr(irSexp);
+
+        var irSexp2 = x.IRReader.ReadIR(sexpText);
+        var sexpTextNormalized2 = x.IRWRiter.WriteIr(irSexp2); 
+        Assert.Equal(sexpTextNormalized ,sexpTextNormalized2);
+    }
+}

--- a/CLVMDotNet/CLVMDotNet.Tools.Tests/UtilsTests.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools.Tests/UtilsTests.cs
@@ -1,0 +1,26 @@
+using System.Numerics;
+using CLVMDotNet.Tools.IR;
+using Xunit;
+
+namespace CLVMDotNet.Tools.Tests;
+
+public class UtilsTests
+{
+    [Theory]
+    [InlineData("1129270867", "CONS")]
+    [InlineData("1314212940", "NULL")]
+    [InlineData("4804180", "INT")]
+    [InlineData("4736344", "HEX")]
+    [InlineData("20820", "QT")]
+    [InlineData("4477268", "DQT")]
+    [InlineData("5460308", "SQT")]
+    [InlineData("5462349", "SYM")]
+    [InlineData("20304", "OP")]
+    [InlineData("1129268293", "CODE")]
+    [InlineData("1313817669", "NODE")]
+    public void Convert_to_base256_matches_python(string expected, string sym)
+    {
+        BigInteger expectedNumber = BigInteger.Parse(expected);
+        Assert.Equal(expectedNumber, Utils.ConvertToBase256(sym));
+    }
+}

--- a/CLVMDotNet/CLVMDotNet.Tools/CLVMDotNet.Tools.csproj
+++ b/CLVMDotNet/CLVMDotNet.Tools/CLVMDotNet.Tools.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\src\CLVMDotNet.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Costs\" />
+    </ItemGroup>
+
+</Project>

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
@@ -1,0 +1,192 @@
+using System.Data;
+using System.Text;
+
+namespace CLVMDotNet.Tools.IR;
+
+public class IRReader
+{
+    private static int ConsumeWhitespace(string s, int offset)
+    {
+        while (true)
+        {
+            while (offset < s.Length && char.IsWhiteSpace(s[offset]))
+            {
+                offset++;
+            }
+            if (offset >= s.Length || s[offset] != ';')
+            {
+                break;
+            }
+            while (offset < s.Length && s[offset] != '\n' && s[offset] != '\r')
+            {
+                offset++;
+            }
+        }
+        return offset;
+    }
+    
+    private static (string, int) ConsumeUntilWhitespace(string s, int offset)
+    {
+        int start = offset;
+        while (offset < s.Length && !char.IsWhiteSpace(s[offset]) && s[offset] != ')')
+        {
+            offset++;
+        }
+        return (s.Substring(start, offset - start), offset);
+    }
+
+    public static (string, int) NextConsToken(Stream stream)
+    {
+        foreach ((string token, int offset) in stream)
+        {
+            return (token, offset);
+        }
+
+        throw new SyntaxErrorException("missing )");
+    }
+    
+    public static IEnumerable<(string, int)> TokenStream(string s)
+    {
+        int offset = 0;
+        while (offset < s.Length)
+        {
+            offset = ConsumeWhitespace(s, offset);
+            if (offset >= s.Length)
+            {
+                break;
+            }
+            char c = s[offset];
+            if (c == '(' || c == ')')
+            {
+                yield return (c.ToString(), offset);
+                offset++;
+                continue;
+            }
+            if (c == '"' || c == '\'')
+            {
+                int start = offset;
+                char initialC = s[start];
+                offset++;
+                while (offset < s.Length && s[offset] != initialC)
+                {
+                    offset++;
+                }
+                if (offset < s.Length)
+                {
+                    yield return (s.Substring(start, offset - start + 1), start);
+                    offset++;
+                    continue;
+                }
+                else
+                {
+                    throw new SyntaxErrorException($"unterminated string starting at {start}: {s[start..]}");
+                }
+            }
+            (string token, int endOffset) = ConsumeUntilWhitespace(s, offset);
+            yield return (token, offset);
+            offset = endOffset;
+        }
+    }
+    
+    public static (Type, int, byte[]) TokenizeSymbol(string token, int offset)
+    {
+        return (Type.SYMBOL, offset, Encoding.UTF8.GetBytes(token));
+    }
+    
+    public static CLVMObject TokenizeHex(string token, int offset)
+    {
+        if (token.Length >= 2 && token.Substring(0, 2).ToUpper() == "0X")
+        {
+            try
+            {
+                token = token.Substring(2);
+                if (token.Length % 2 == 1)
+                {
+                    token = "0" + token;
+                }
+                return IrNew(Type.HEX, HexStringToBytes(token), offset);
+            }
+            catch (Exception)
+            {
+                throw new SyntaxErrorException($"invalid hex at {offset}: 0x{token}");
+            }
+        }
+        return null;
+    }
+    
+    public static (Type, int, byte[])? TokenizeQuotes(string token, int offset)
+    {
+        if (token.Length < 2)
+        {
+            return null;
+        }
+        char c = token[0];
+        if (c != '\'' && c != '"')
+        {
+            return null;
+        }
+
+        if (token[token.Length - 1] != c)
+        {
+            throw new SyntaxErrorException($"unterminated string starting at {offset}: {token}");
+        }
+
+        Type qType = (c == '\'') ? Type.SINGLE_QUOTE : Type.DOUBLE_QUOTE;
+
+        return (qType, offset, Encoding.UTF8.GetBytes(token.Substring(1, token.Length - 2)));
+    }
+
+
+    private static byte[] HexStringToBytes(string hex)
+    {
+        int numberChars = hex.Length;
+        byte[] bytes = new byte[numberChars / 2];
+        for (int i = 0; i < numberChars; i += 2)
+        {
+            bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+        }
+        return bytes;
+    }
+
+    
+    public static CLVMObject TokenizeSexp(string token, int offset, Stream stream)
+    {
+        if (token == "(")
+        {
+            (string nextToken, int nextOffset) = NextConsToken(stream);
+            return TokenizeCons(nextToken, nextOffset, stream);
+        }
+
+        Func<string, int, CLVMObject>[] functions = new Func<string, int, CLVMObject>[]
+        {
+            TokenizeInt,
+            TokenizeHex,
+            TokenizeQuotes,
+            TokenizeSymbol,
+        };
+
+        foreach (Func<string, int, CLVMObject> f in functions)
+        {
+            CLVMObject result = f(token, offset);
+            if (result != null)
+            {
+                return result;
+            }
+        }
+
+        return null;
+    }
+    
+    
+    public static SExp ReadIr(string s)
+    {
+        var stream = TokenStream(s);
+
+        foreach ((string token, int offset) in stream)
+        {
+            return toSexp(TokenizeSexp(token, offset, stream));
+        }
+
+        throw new SyntaxErrorException("unexpected end of stream");
+    }
+}

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
@@ -332,6 +332,15 @@ public class IRReader
     public static SExp ReadIR(string s)
     {
         var stream = TokenStream(s);
+
+        // foreach (var item in stream)
+        // {
+        //     Console.WriteLine($"{item.token} - {item.offset}");
+        // }
+        //
+        // var t = "";
+        // return null;
+
         var enumerator = stream.GetEnumerator();
         while (enumerator.MoveNext())
         {

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
@@ -1,13 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Text;
-using System.Linq;
+using System.Collections;
 using System.Numerics;
-using CLVMDotNet;
-using CLVMDotNet.Tools.IR;
+using System.Text;
 
-public class Tokenizer
+namespace CLVMDotNet.Tools.IR;
+public class IRReader
 {
     public delegate CLVMObject TokenizeSexpDelegate(string token, int offset, IEnumerator<Token> stream);
 
@@ -92,7 +88,7 @@ public class Tokenizer
             }
         }
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
@@ -303,7 +299,7 @@ public class Tokenizer
         return Tuple.Create((IRType.SYMBOL, offset),token);
     }
 
-    static IEnumerable<(string token, int offset)> TokenStream(string s)
+    public static IEnumerable<(string token, int offset)> TokenStream(string s)
     {
         int offset = 0;
         while (offset < s.Length)
@@ -365,12 +361,5 @@ public class Tokenizer
         }
         
         throw new ArgumentException("unexpected end of stream");
-    }
-
-    public class SyntaxException : Exception
-    {
-        public SyntaxException(string message) : base(message)
-        {
-        }
     }
 }

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
@@ -351,7 +351,6 @@ public class IRReader
     public static SExp ReadIR(string s)
     {
         var stream = TokenStream(s);
-
         var enumerator = stream.GetEnumerator();
         while (enumerator.MoveNext())
         {

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
@@ -1,51 +1,303 @@
+using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Text;
+using System.Linq;
+using CLVMDotNet;
+using CLVMDotNet.Tools.IR;
 
-namespace CLVMDotNet.Tools.IR;
-
-public class IRReader
+public class Tokenizer
 {
-    private static int ConsumeWhitespace(string s, int offset)
+    public delegate CLVMObject TokenizeSexpDelegate(string token, int offset, IEnumerator<Token> stream);
+
+    public delegate CLVMObject ReadIRDelegate(string s, Func<CLVMObject, byte[]> toSexp);
+
+    public delegate CLVMObject TokenizeConsDelegate(string token, int offset, IEnumerator<Token> stream);
+
+    public delegate Tuple<string, int> NextConsTokenDelegate(IEnumerator<Token> stream);
+
+    public delegate Tuple<Tuple<IRType, int>, byte[]> TokenizeQuotesDelegate(string token, int offset);
+
+    public delegate Tuple<Tuple<IRType, int>, byte[]> TokenizeSymbolDelegate(string token, int offset);
+
+    public delegate bool TryParseIntDelegate(string token, out int result);
+
+    public delegate bool TryParseHexDelegate(string token, out byte[] result);
+
+    public delegate Stream TokenStreamDelegate(string s);
+
+
+    public class Token
     {
-        while (true)
+        public string Value { get; set; }
+        public int Offset { get; set; }
+    }
+
+    public class Stream : IEnumerable<Token>
+    {
+        private readonly string s;
+        private int offset;
+
+        public Stream(string s)
         {
-            while (offset < s.Length && char.IsWhiteSpace(s[offset]))
+            this.s = s;
+            offset = 0;
+        }
+
+        public IEnumerator<Token> GetEnumerator()
+        {
+            while (offset < s.Length)
             {
-                offset++;
+                offset = ConsumeWhitespace(s, offset);
+                if (offset >= s.Length)
+                {
+                    break;
+                }
+
+                char c = s[offset];
+                if (c == '(' || c == ')')
+                {
+                    yield return new Token { Value = c.ToString(), Offset = offset };
+                    offset++;
+                    continue;
+                }
+
+                if (c == '"' || c == '\'')
+                {
+                    int start = offset;
+                    char initialC = s[start];
+                    offset++;
+                    while (offset < s.Length && s[offset] != initialC)
+                    {
+                        offset++;
+                    }
+
+                    if (offset < s.Length)
+                    {
+                        yield return new Token { Value = s.Substring(start, offset - start + 1), Offset = start };
+                        offset++;
+                        continue;
+                    }
+                    else
+                    {
+                        throw new SyntaxException(
+                            "unterminated string starting at " + start + ": " + s.Substring(start));
+                    }
+                }
+
+                Tuple<string, int> tokenAndEndOffset = ConsumeUntilWhitespace(s, offset);
+                yield return new Token { Value = tokenAndEndOffset.Item1, Offset = offset };
+                offset = tokenAndEndOffset.Item2;
             }
-            if (offset >= s.Length || s[offset] != ';')
-            {
-                break;
-            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    public static int ConsumeWhitespace(string s, int offset)
+    {
+        while (offset < s.Length && char.IsWhiteSpace(s[offset]))
+        {
+            offset++;
+        }
+
+        if (offset < s.Length && s[offset] == ';')
+        {
             while (offset < s.Length && s[offset] != '\n' && s[offset] != '\r')
             {
                 offset++;
             }
         }
+
         return offset;
     }
-    
-    private static (string, int) ConsumeUntilWhitespace(string s, int offset)
+
+    public static Tuple<string, int> ConsumeUntilWhitespace(string s, int offset)
     {
         int start = offset;
         while (offset < s.Length && !char.IsWhiteSpace(s[offset]) && s[offset] != ')')
         {
             offset++;
         }
-        return (s.Substring(start, offset - start), offset);
+
+        return new Tuple<string, int>(s.Substring(start, offset - start), offset);
     }
 
-    public static (string, int) NextConsToken(Stream stream)
+    public static (string, int) NextConsToken(IEnumerator<(string,int)> stream)
     {
-        foreach ((string token, int offset) in stream)
+        string token = null;
+        int offset = -1;
+
+        stream.MoveNext();
+        // foreach (var item in stream.)
+        // {
+        //     token = item.Item1;
+        //     offset = item.Item2;
+        //     break;
+        // }
+
+        token = stream.Current.Item1;
+        offset = stream.Current.Item2;
+
+        if (token == null)
         {
-            return (token, offset);
+            throw new SyntaxException("Missing )");
         }
 
-        throw new SyntaxErrorException("missing )");
+        return (token, offset);
     }
+
+    public static dynamic? TokenizeCons(string token, int offset, IEnumerator<(string, int)> stream)
+    {
+        if (token == ")")
+        {
+            return Utils.IrNew(IRType.NULL, 0, offset);
+        }
+
+        int initialOffset = offset;
+        var firstSexp = TokenizeSexp(token, offset, stream);
+
+        var nextToken = NextConsToken(stream);
+        token = nextToken.Item1;
+        offset = nextToken.Item2;
+
+        if (token == ".")
+        {
+            int dotOffset = offset;
+            // grab the last item
+            nextToken = NextConsToken(stream);
+            token = nextToken.Item1;
+            offset = nextToken.Item2;
+
+            var restSexp = TokenizeSexp(token, offset, stream);
+
+            nextToken = NextConsToken(stream);
+            token = nextToken.Item1;
+            offset = nextToken.Item2;
+
+            if (token != ")")
+            {
+                throw new SyntaxException("illegal dot expression at " + dotOffset);
+            }
+
+            return Utils.IrCons(firstSexp, restSexp, initialOffset);
+        }
+        else
+        {
+            var restSexp = TokenizeCons(token, offset, stream);
+            return Utils.IrCons(firstSexp, restSexp, initialOffset);
+        }
+    }
+
+
+    public static dynamic? TokenizeSexp(string token, int offset, IEnumerator<(string, int)> stream)
+    {
+        if (token == "(")
+        {
+            var (t, o) = NextConsToken(stream);
+            token = t;
+            offset = o;
+            return TokenizeCons(token, offset, stream);
+        }
     
-    public static IEnumerable<(string, int)> TokenStream(string s)
+        var result = TokenizeInt(token, offset);
+        if (result != null)
+            return result;
+        var hex  = TokenizeHex(token, offset);
+        if (hex != null)
+            return hex;
+        var quotes = TokenizeQuotes(token, offset);
+        if (quotes != null)
+            return quotes;
+        var symbol = TokenizeSymbol(token, offset);
+        if (symbol != null)
+            return symbol;
+
+        return null;
+    }
+
+    public static SExp? TokenizeInt(string token, int offset)
+    {
+        if (int.TryParse(token, out int result))
+        {
+            return Utils.IrNew(IRType.INT, result, offset);
+        }
+
+        return null;
+    }
+
+    public static SExp? TokenizeHex(string token, int offset)
+    {
+        if (token.Length >= 2 && token.Substring(0, 2).ToUpper() == "0X")
+        {
+            string hexValue = token.Substring(2);
+            if (hexValue.Length % 2 == 1)
+            {
+                hexValue = "0" + hexValue;
+            }
+
+            if (TryParseHex(hexValue, out byte[] result))
+            {
+                return Utils.IrNew(IRType.HEX, result, offset);
+            }
+            else
+            {
+                throw new SyntaxException("invalid hex at " + offset + ": 0x" + token);
+            }
+        }
+
+        return null;
+    }
+
+    public static bool TryParseHex(string token, out byte[] result)
+    {
+        try
+        {
+            result = Enumerable.Range(0, token.Length)
+                .Where(x => x % 2 == 0)
+                .Select(x => Convert.ToByte(token.Substring(x, 2), 16))
+                .ToArray();
+            return true;
+        }
+        catch
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    public static Tuple<Tuple<IRType, int>, byte[]>? TokenizeQuotes(string token, int offset)
+    {
+        if (token.Length >= 2)
+        {
+            char c = token[0];
+            if (c == '\'' || c == '"')
+            {
+                if (token[token.Length - 1] == c)
+                {
+                    IRType qType = (c == '\'') ? IRType.SINGLE_QUOTE : IRType.DOUBLE_QUOTE;
+                    byte[] value = Encoding.UTF8.GetBytes(token.Substring(1, token.Length - 2));
+                    return new Tuple<Tuple<IRType, int>, byte[]>(new Tuple<IRType, int>(qType, offset), value);
+                }
+                else
+                {
+                    throw new SyntaxException("unterminated string starting at " + offset + ": " + token);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public static Tuple<(IRType, int), string>? TokenizeSymbol(string token, int offset)
+    {
+        return Tuple.Create((IRType.SYMBOL, offset),token);
+    }
+
+    static IEnumerable<(string token, int offset)> TokenStream(string s)
     {
         int offset = 0;
         while (offset < s.Length)
@@ -53,8 +305,9 @@ public class IRReader
             offset = ConsumeWhitespace(s, offset);
             if (offset >= s.Length)
             {
-                break;
+                yield break;
             }
+
             char c = s[offset];
             if (c == '(' || c == ')')
             {
@@ -62,6 +315,7 @@ public class IRReader
                 offset++;
                 continue;
             }
+
             if (c == '"' || c == '\'')
             {
                 int start = offset;
@@ -71,6 +325,7 @@ public class IRReader
                 {
                     offset++;
                 }
+
                 if (offset < s.Length)
                 {
                     yield return (s.Substring(start, offset - start + 1), start);
@@ -79,114 +334,35 @@ public class IRReader
                 }
                 else
                 {
-                    throw new SyntaxErrorException($"unterminated string starting at {start}: {s[start..]}");
+                    throw new SyntaxException(
+                        $"Unterminated string starting at {start}: {s.Substring(start)}"
+                    );
                 }
             }
+
             (string token, int endOffset) = ConsumeUntilWhitespace(s, offset);
             yield return (token, offset);
             offset = endOffset;
         }
     }
-    
-    public static (Type, int, byte[]) TokenizeSymbol(string token, int offset)
-    {
-        return (Type.SYMBOL, offset, Encoding.UTF8.GetBytes(token));
-    }
-    
-    public static CLVMObject TokenizeHex(string token, int offset)
-    {
-        if (token.Length >= 2 && token.Substring(0, 2).ToUpper() == "0X")
-        {
-            try
-            {
-                token = token.Substring(2);
-                if (token.Length % 2 == 1)
-                {
-                    token = "0" + token;
-                }
-                return IrNew(Type.HEX, HexStringToBytes(token), offset);
-            }
-            catch (Exception)
-            {
-                throw new SyntaxErrorException($"invalid hex at {offset}: 0x{token}");
-            }
-        }
-        return null;
-    }
-    
-    public static (Type, int, byte[])? TokenizeQuotes(string token, int offset)
-    {
-        if (token.Length < 2)
-        {
-            return null;
-        }
-        char c = token[0];
-        if (c != '\'' && c != '"')
-        {
-            return null;
-        }
 
-        if (token[token.Length - 1] != c)
-        {
-            throw new SyntaxErrorException($"unterminated string starting at {offset}: {token}");
-        }
-
-        Type qType = (c == '\'') ? Type.SINGLE_QUOTE : Type.DOUBLE_QUOTE;
-
-        return (qType, offset, Encoding.UTF8.GetBytes(token.Substring(1, token.Length - 2)));
-    }
-
-
-    private static byte[] HexStringToBytes(string hex)
-    {
-        int numberChars = hex.Length;
-        byte[] bytes = new byte[numberChars / 2];
-        for (int i = 0; i < numberChars; i += 2)
-        {
-            bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
-        }
-        return bytes;
-    }
-
-    
-    public static CLVMObject TokenizeSexp(string token, int offset, Stream stream)
-    {
-        if (token == "(")
-        {
-            (string nextToken, int nextOffset) = NextConsToken(stream);
-            return TokenizeCons(nextToken, nextOffset, stream);
-        }
-
-        Func<string, int, CLVMObject>[] functions = new Func<string, int, CLVMObject>[]
-        {
-            TokenizeInt,
-            TokenizeHex,
-            TokenizeQuotes,
-            TokenizeSymbol,
-        };
-
-        foreach (Func<string, int, CLVMObject> f in functions)
-        {
-            CLVMObject result = f(token, offset);
-            if (result != null)
-            {
-                return result;
-            }
-        }
-
-        return null;
-    }
-    
-    
-    public static SExp ReadIr(string s)
+    public static SExp ReadIR(string s)
     {
         var stream = TokenStream(s);
-
-        foreach ((string token, int offset) in stream)
+        var enumerator = stream.GetEnumerator();
+        while (enumerator.MoveNext())
         {
-            return toSexp(TokenizeSexp(token, offset, stream));
+            var item = enumerator.Current;
+            return SExp.To(TokenizeSexp(item.token, item.offset, enumerator));
         }
 
-        throw new SyntaxErrorException("unexpected end of stream");
+        throw new ArgumentException("unexpected end of stream");
+    }
+
+    public class SyntaxException : Exception
+    {
+        public SyntaxException(string message) : base(message)
+        {
+        }
     }
 }

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRReader.cs
@@ -5,25 +5,6 @@ using System.Text;
 namespace CLVMDotNet.Tools.IR;
 public class IRReader
 {
-    public delegate CLVMObject TokenizeSexpDelegate(string token, int offset, IEnumerator<Token> stream);
-
-    public delegate CLVMObject ReadIRDelegate(string s, Func<CLVMObject, byte[]> toSexp);
-
-    public delegate CLVMObject TokenizeConsDelegate(string token, int offset, IEnumerator<Token> stream);
-
-    public delegate Tuple<string, int> NextConsTokenDelegate(IEnumerator<Token> stream);
-
-    public delegate Tuple<Tuple<IRType, int>, byte[]> TokenizeQuotesDelegate(string token, int offset);
-
-    public delegate Tuple<Tuple<IRType, int>, byte[]> TokenizeSymbolDelegate(string token, int offset);
-
-    public delegate bool TryParseIntDelegate(string token, out int result);
-
-    public delegate bool TryParseHexDelegate(string token, out byte[] result);
-
-    public delegate Stream TokenStreamDelegate(string s);
-
-
     public class Token
     {
         public string Value { get; set; }

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRType.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRType.cs
@@ -1,0 +1,39 @@
+using System.Numerics;
+
+namespace CLVMDotNet.Tools.IR;
+
+public class IRType
+{
+    public static IRType CONS = new IRType(0x434F4E53); // Equivalent to b"CONS"
+    public static IRType NULL = new IRType(0x4E554C4C); // Equivalent to b"NULL"
+    public static IRType INT = new IRType(0x494E54); // Equivalent to b"INT"
+    public static IRType HEX = new IRType(0x484558); // Equivalent to b"HEX"
+    public static IRType QUOTES = new IRType(0x5154); // Equivalent to b"QT"
+    public static IRType DOUBLE_QUOTE = new IRType(0x44515454); // Equivalent to b"DQT"
+    public static IRType SINGLE_QUOTE = new IRType(0x53515454); // Equivalent to b"SQT"
+    public static IRType SYMBOL = new IRType(0x53594D42); // Equivalent to b"SYM"
+    public static IRType OPERATOR = new IRType(0x4F50); // Equivalent to b"OP"
+    public static IRType CODE = new IRType(0x434F4445); // Equivalent to b"CODE"
+    public static IRType NODE = new IRType(0x4E4F4445); // Equivalent to b"NODE"
+    public BigInteger _val { get; private set; }
+    
+    public IRType(BigInteger val)
+    {
+        _val = val;
+    }
+    
+    public bool Listp()
+    {
+        return false;
+    }
+
+    public byte[] AsAtom()
+    {
+        return Casts.IntToBytes(_val);
+    }
+
+    public int BitLength()
+    {
+        return (int)Math.Ceiling(BigInteger.Log(_val, 256) / 8);
+    }
+}

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRType.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRType.cs
@@ -4,17 +4,17 @@ namespace CLVMDotNet.Tools.IR;
 
 public class IRType
 {
-    public static IRType CONS = new IRType(0x434F4E53); // Equivalent to b"CONS"
-    public static IRType NULL = new IRType(0x4E554C4C); // Equivalent to b"NULL"
-    public static IRType INT = new IRType(0x494E54); // Equivalent to b"INT"
-    public static IRType HEX = new IRType(0x484558); // Equivalent to b"HEX"
-    public static IRType QUOTES = new IRType(0x5154); // Equivalent to b"QT"
-    public static IRType DOUBLE_QUOTE = new IRType(0x44515454); // Equivalent to b"DQT"
-    public static IRType SINGLE_QUOTE = new IRType(0x53515454); // Equivalent to b"SQT"
-    public static IRType SYMBOL = new IRType(0x53594D42); // Equivalent to b"SYM"
-    public static IRType OPERATOR = new IRType(0x4F50); // Equivalent to b"OP"
-    public static IRType CODE = new IRType(0x434F4445); // Equivalent to b"CODE"
-    public static IRType NODE = new IRType(0x4E4F4445); // Equivalent to b"NODE"
+    public static IRType CONS = new IRType(Utils.ConvertToBase256("CONS")); // Equivalent to b"CONS"
+    public static IRType NULL = new IRType(Utils.ConvertToBase256("NULL")); // Equivalent to b"NULL"
+    public static IRType INT = new IRType(Utils.ConvertToBase256("INT")); // Equivalent to b"INT"
+    public static IRType HEX = new IRType(Utils.ConvertToBase256("HEX")); // Equivalent to b"HEX"
+    public static IRType QUOTES = new IRType(Utils.ConvertToBase256("QT")); // Equivalent to b"QT"
+    public static IRType DOUBLE_QUOTE = new IRType(Utils.ConvertToBase256("DQT")); // Equivalent to b"DQT"
+    public static IRType SINGLE_QUOTE = new IRType(Utils.ConvertToBase256("SQT")); // Equivalent to b"SQT"
+    public static IRType SYMBOL = new IRType(Utils.ConvertToBase256("SYM")); // Equivalent to b"SYM"
+    public static IRType OPERATOR = new IRType(Utils.ConvertToBase256("OP")); // Equivalent to b"OP"
+    public static IRType CODE = new IRType(Utils.ConvertToBase256("CODE")); // Equivalent to b"CODE"
+    public static IRType NODE = new IRType(Utils.ConvertToBase256("NODE")); // Equivalent to b"NODE"
     public BigInteger _val { get; private set; }
     
     public IRType(BigInteger val)

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRType.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRType.cs
@@ -15,8 +15,8 @@ public class IRType
     public static BigInteger OPERATOR = Utils.ConvertToBase256("OP"); // Equivalent to b"OP"
     public static BigInteger CODE = Utils.ConvertToBase256("CODE"); // Equivalent to b"CODE"
     public static BigInteger NODE = Utils.ConvertToBase256("NODE"); // Equivalent to b"NODE"
+    public static BigInteger[] CONS_TYPES => new[] { CONS };
 
-    
     public static bool Listp()
     {
         return false;

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRType.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRType.cs
@@ -4,36 +4,31 @@ namespace CLVMDotNet.Tools.IR;
 
 public class IRType
 {
-    public static IRType CONS = new IRType(Utils.ConvertToBase256("CONS")); // Equivalent to b"CONS"
-    public static IRType NULL = new IRType(Utils.ConvertToBase256("NULL")); // Equivalent to b"NULL"
-    public static IRType INT = new IRType(Utils.ConvertToBase256("INT")); // Equivalent to b"INT"
-    public static IRType HEX = new IRType(Utils.ConvertToBase256("HEX")); // Equivalent to b"HEX"
-    public static IRType QUOTES = new IRType(Utils.ConvertToBase256("QT")); // Equivalent to b"QT"
-    public static IRType DOUBLE_QUOTE = new IRType(Utils.ConvertToBase256("DQT")); // Equivalent to b"DQT"
-    public static IRType SINGLE_QUOTE = new IRType(Utils.ConvertToBase256("SQT")); // Equivalent to b"SQT"
-    public static IRType SYMBOL = new IRType(Utils.ConvertToBase256("SYM")); // Equivalent to b"SYM"
-    public static IRType OPERATOR = new IRType(Utils.ConvertToBase256("OP")); // Equivalent to b"OP"
-    public static IRType CODE = new IRType(Utils.ConvertToBase256("CODE")); // Equivalent to b"CODE"
-    public static IRType NODE = new IRType(Utils.ConvertToBase256("NODE")); // Equivalent to b"NODE"
-    public BigInteger _val { get; private set; }
+    public static BigInteger CONS = Utils.ConvertToBase256("CONS"); // Equivalent to b"CONS"
+    public static BigInteger NULL = Utils.ConvertToBase256("NULL"); // Equivalent to b"NULL"
+    public static BigInteger INT = Utils.ConvertToBase256("INT"); // Equivalent to b"INT"
+    public static BigInteger HEX = Utils.ConvertToBase256("HEX"); // Equivalent to b"HEX"
+    public static BigInteger QUOTES = Utils.ConvertToBase256("QT"); // Equivalent to b"QT"
+    public static BigInteger DOUBLE_QUOTE = Utils.ConvertToBase256("DQT"); // Equivalent to b"DQT"
+    public static BigInteger SINGLE_QUOTE = Utils.ConvertToBase256("SQT"); // Equivalent to b"SQT"
+    public static BigInteger SYMBOL = Utils.ConvertToBase256("SYM"); // Equivalent to b"SYM"
+    public static BigInteger OPERATOR = Utils.ConvertToBase256("OP"); // Equivalent to b"OP"
+    public static BigInteger CODE = Utils.ConvertToBase256("CODE"); // Equivalent to b"CODE"
+    public static BigInteger NODE = Utils.ConvertToBase256("NODE"); // Equivalent to b"NODE"
+
     
-    public IRType(BigInteger val)
-    {
-        _val = val;
-    }
-    
-    public bool Listp()
+    public static bool Listp()
     {
         return false;
     }
 
-    public byte[] AsAtom()
+    public byte[] AsAtom(BigInteger val)
     {
-        return Casts.IntToBytes(_val);
+        return Casts.IntToBytes(val);
     }
 
-    public int BitLength()
+    public static int BitLength(BigInteger val)
     {
-        return (int)Math.Ceiling(BigInteger.Log(_val, 256) / 8);
+        return (int)Math.Ceiling(BigInteger.Log(val, 256) / 8);
     }
 }

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/IRWRiter.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/IRWRiter.cs
@@ -1,0 +1,144 @@
+using System.Data;
+
+namespace CLVMDotNet.Tools.IR;
+
+public static class IRWRiter
+{
+    public static IEnumerable<string> IterSexpFormat(SExp irSexp)
+    {
+        yield return "(";
+        bool isFirst = true;
+        while (!Utils.IrNullp(irSexp))
+        {
+            if (!Utils.IrListp(irSexp))
+            {
+                yield return " . ";
+                foreach (var item in IterIrFormat(irSexp))
+                {
+                    yield return item;
+                }
+
+                yield break;
+            }
+
+            if (!isFirst)
+            {
+                yield return " ";
+            }
+
+            foreach (var item in IterIrFormat(Utils.IrFirst(irSexp)))
+            {
+                yield return item;
+            }
+
+            irSexp = Utils.IrRest(irSexp);
+            isFirst = false;
+        }
+
+        yield return ")";
+    }
+
+    public static IEnumerable<string> IterIrFormat(SExp irSexp)
+    {
+        if (Utils.IrListp(irSexp))
+        {
+            foreach (var item in IterSexpFormat(irSexp))
+            {
+                yield return item;
+            }
+
+            yield break;
+        }
+
+        var type = Utils.IrType(irSexp);
+
+        if (type == IRType.CODE)
+        {
+            using (var bio = new MemoryStream())
+            {
+                Serialize.SexpToStream(Utils.IrVal(irSexp), bio);
+                var code = BitConverter.ToString(bio.ToArray()).Replace("-", "");
+                yield return $"CODE[{code}]";
+            }
+
+            yield break;
+        }
+
+        if (type == IRType.NULL)
+        {
+            yield return "()";
+            yield break;
+        }
+
+        var atom = Utils.IrAsAtom(irSexp);
+
+        if (type == IRType.INT)
+        {
+            yield return $"{Casts.IntFromBytes(atom)}";
+        }
+        else if (type == IRType.NODE)
+        {
+            yield return $"NODE[{Casts.IntFromBytes(atom)}]";
+        }
+        else if (type == IRType.HEX)
+        {
+            yield return $"0x{BitConverter.ToString(atom).Replace("-", "")}";
+        }
+        else if (type == IRType.QUOTES)
+        {
+            yield return $"\"{System.Text.Encoding.UTF8.GetString(atom)}\"";
+        }
+        else if (type == IRType.DOUBLE_QUOTE)
+        {
+            yield return $"\"{System.Text.Encoding.UTF8.GetString(atom)}\"";
+        }
+        else if (type == IRType.SINGLE_QUOTE)
+        {
+            yield return $"'{System.Text.Encoding.UTF8.GetString(atom)}'";
+        }
+        else if (new[] { IRType.SYMBOL, IRType.OPERATOR }.Contains(type))
+        {
+            string? val = null;
+            string? error = null;
+            try
+            {
+                 val = System.Text.Encoding.UTF8.GetString(atom);
+            }
+            catch (Exception)
+            {
+                error = $"(indecipherable symbol: {BitConverter.ToString(atom)})";
+            }
+
+            if (!string.IsNullOrEmpty(error))
+                yield return error;
+            else
+            {
+                yield return val!;
+            }
+        }
+        else
+        {
+            throw new SyntaxErrorException($"bad ir format: {irSexp}");
+        }
+    }
+
+    public static void WriteIrToStream(SExp irSexp, Stream stream)
+    {
+        using (var writer = new StreamWriter(stream))
+        {
+            foreach (var item in IterIrFormat(irSexp))
+            {
+                writer.Write(item);
+            }
+        }
+    }
+
+    public static string WriteIr(SExp irSexp)
+    {
+        using (var stream = new MemoryStream())
+        {
+            WriteIrToStream(irSexp, stream);
+            return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        }
+    }
+}

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
@@ -1,0 +1,107 @@
+using System.Numerics;
+
+namespace CLVMDotNet.Tools.IR;
+
+public class Utils
+{
+    public static SExp IrNew(IRType type, dynamic val, int? offset = null)
+    {
+        if (offset.HasValue)
+        {
+            return SExp.To(new Tuple<BigInteger, BigInteger>(type._val, offset.Value));
+        }
+
+        return SExp.To(new Tuple<BigInteger, dynamic>(type._val, val));
+    }
+    
+    public static SExp IrNew(SExp first, SExp rest)
+    {
+        return SExp.To((first, rest));
+    }
+    
+    public static SExp IrCons(SExp first, SExp rest, int? offset = null)
+    {
+        return IrNew(IRType.CONS, IrNew(first, rest), offset);
+    }
+    
+    public static SExp IrNull()
+    {
+        return IrNew(IRType.NULL, 0);
+    }
+    
+    public static BigInteger IrType(SExp irSexp)
+    {
+        SExp theType = irSexp.First();
+        if (theType.Listp())
+        {
+            theType = theType.First();
+        }
+
+        return Casts.IntFromBytes(theType.AsAtom());
+    }
+    
+    public static BigInteger IrOffset(SExp irSexp)
+    {
+        SExp theOffset = irSexp.First();
+        if (theOffset.Listp())
+        {
+            theOffset.Atom = theOffset.Rest().AsAtom();
+        }
+        // else
+        // {
+        //     theOffset = new SExp(new byte[] { 0xff }); // Assuming b"\xff" in Python corresponds to new byte[] { 0xff } in C#
+        // }
+
+        return Casts.IntFromBytes(theOffset.AsAtom());
+    }
+    
+    // public static int IrAsInt(SExp irSexp)
+    // {
+    //     return Casts.IntFromBytes(IrAsAtom(irSexp));
+    // }
+    
+    public static bool IsIr(SExp sexp)
+    {
+        if (sexp.Atom != null)
+        {
+            return false;
+        }
+
+        Tuple<dynamic, dynamic> pair = sexp.Pair;
+        byte[] f = pair.Item1.Atom;
+        if (f == null || f.Length > 1)
+        {
+            return false;
+        }
+
+        var theType = Casts.IntFromBytes(f);
+        try
+        {
+            IRType t = new IRType(theType);
+            if (t._val == IRType.CONS._val)
+            {
+                if (pair.Item2.Atom != null && pair.Item2.Atom.Length == 0)
+                {
+                    return true;
+                }
+                if (pair.Item2.Pair != null)
+                {
+                    foreach (SExp item in pair.Item2.Pair)
+                    {
+                        if (!IsIr(item))
+                        {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+            }
+            return pair.Item2.Atom != null;
+        }
+        catch (InvalidCastException)
+        {
+            return false;
+        }
+    }
+
+}

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
@@ -18,14 +18,14 @@ public class Utils
         return val;
     }
     
-    public static SExp IrNew(IRType type, dynamic val, int? offset = null)
+    public static SExp IrNew(BigInteger type, dynamic val, int? offset = null)
     {
         if (offset.HasValue)
         {
-            return SExp.To(new Tuple<BigInteger, BigInteger>(type._val, offset.Value));
+            return SExp.To(new Tuple<dynamic, dynamic>(type, offset));
         }
 
-        return SExp.To(new Tuple<BigInteger, dynamic>(type._val, val));
+        return SExp.To(new Tuple<BigInteger, dynamic>(type, val));
     }
     
     public static SExp IrNew(SExp first, SExp rest)
@@ -33,7 +33,7 @@ public class Utils
         return SExp.To((first, rest));
     }
     
-    public static SExp IrCons(SExp first, SExp rest, int? offset = null)
+    public static SExp IrCons(dynamic first, dynamic rest, int? offset = null)
     {
         return IrNew(IRType.CONS, IrNew(first, rest), offset);
     }
@@ -91,8 +91,7 @@ public class Utils
         var theType = Casts.IntFromBytes(f);
         try
         {
-            IRType t = new IRType(theType);
-            if (t._val == IRType.CONS._val)
+            if (theType == IRType.CONS)
             {
                 if (pair.Item2.Atom != null && pair.Item2.Atom.Length == 0)
                 {

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
@@ -4,6 +4,7 @@ using System.Text;
 namespace CLVMDotNet.Tools.IR;
 
 public class Utils
+
 {
     public static BigInteger ConvertToBase256(string s)
     {

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
@@ -1,9 +1,23 @@
 using System.Numerics;
+using System.Text;
 
 namespace CLVMDotNet.Tools.IR;
 
 public class Utils
 {
+    public static BigInteger ConvertToBase256(string s)
+    {
+        byte[] byteArray = Encoding.UTF8.GetBytes(s);
+        int val = 0;
+
+        for (int i = 0; i < byteArray.Length; i++)
+        {
+            val = (val << 8) | byteArray[i];
+        }
+
+        return val;
+    }
+    
     public static SExp IrNew(IRType type, dynamic val, int? offset = null)
     {
         if (offset.HasValue)

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
@@ -24,7 +24,8 @@ public class Utils
         if (offset.HasValue)
         {
             var t = SExp.To(new Tuple<dynamic, dynamic>(type, offset));
-            return SExp.To(new Tuple<dynamic, dynamic>(t, val));
+            var sexp = SExp.To(new Tuple<dynamic, dynamic>(t, val));
+            return sexp;
         }
 
         return SExp.To(new Tuple<dynamic, dynamic>(type, val));
@@ -45,15 +46,37 @@ public class Utils
         return IrNew(IRType.NULL, 0);
     }
     
+    public static bool IrListp(SExp irSexp)
+    {
+        var irType = IrType(irSexp);
+        return IRType.CONS_TYPES.Contains(irType); 
+    }
+    
+    public static bool IrNullp(SExp irSexp)
+    {
+        return IrType(irSexp) == IRType.NULL;
+    }
+    
     public static BigInteger IrType(SExp irSexp)
     {
         SExp theType = irSexp.First();
         if (theType.Listp())
         {
-            theType = theType.First();
+            dynamic first = theType.First();
+            return Casts.IntFromBytes(first.AsAtom());
         }
 
         return Casts.IntFromBytes(theType.AsAtom());
+    }
+    
+    public static SExp IrVal(SExp irSexp)
+    {
+        return irSexp.Rest();
+    }
+    
+    public static SExp IrFirst(SExp irSexp)
+    {
+        return irSexp.Rest().First();
     }
     
     public static BigInteger IrOffset(SExp irSexp)
@@ -63,18 +86,29 @@ public class Utils
         {
             theOffset.Atom = theOffset.Rest().AsAtom();
         }
-        // else
-        // {
-        //     theOffset = new SExp(new byte[] { 0xff }); // Assuming b"\xff" in Python corresponds to new byte[] { 0xff } in C#
-        // }
-
+        else
+        {
+            theOffset = new SExp(new byte[] { 0xff });
+        }
         return Casts.IntFromBytes(theOffset.AsAtom());
     }
     
-    // public static int IrAsInt(SExp irSexp)
-    // {
-    //     return Casts.IntFromBytes(IrAsAtom(irSexp));
-    // }
+    public static BigInteger IrAsInt(SExp irSexp)
+    {
+        var atom = IrAsAtom(irSexp);
+        return Casts.IntFromBytes(atom);
+    }
+    
+    public static byte[] IrAsAtom(SExp irSexp)
+    {
+        var rest = irSexp.Rest().AsAtom();
+        return rest;
+    }
+    
+    public static SExp IrRest(SExp irSexp)
+    {
+        return irSexp.Rest().Rest();
+    }
     
     public static bool IsIr(SExp sexp)
     {

--- a/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/IR/Utils.cs
@@ -19,14 +19,15 @@ public class Utils
         return val;
     }
     
-    public static SExp IrNew(BigInteger type, dynamic val, int? offset = null)
+    public static SExp IrNew(dynamic type, dynamic val, int? offset = null)
     {
         if (offset.HasValue)
         {
-            return SExp.To(new Tuple<dynamic, dynamic>(type, offset));
+            var t = SExp.To(new Tuple<dynamic, dynamic>(type, offset));
+            return SExp.To(new Tuple<dynamic, dynamic>(t, val));
         }
 
-        return SExp.To(new Tuple<BigInteger, dynamic>(type, val));
+        return SExp.To(new Tuple<dynamic, dynamic>(type, val));
     }
     
     public static SExp IrNew(SExp first, SExp rest)

--- a/CLVMDotNet/CLVMDotNet.Tools/SHA256Tree.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/SHA256Tree.cs
@@ -1,0 +1,47 @@
+using System.Security.Cryptography;
+
+namespace CLVMDotNet.Tools;
+
+public static class SHA256Tree
+{
+    public static byte[] Sha256Tree(SExp v)
+    {
+        if (v.Pair != null)
+        {
+            byte[] left = Sha256Tree(v.Pair.Item1);
+            byte[] right = Sha256Tree(v.Pair.Item2);
+            byte[] s = new byte[1] { 0x02 };
+            s = CombineByteArrays(s, left, right);
+            return Sha256Hash(s);
+        }
+        else
+        {
+            byte[] s = new byte[1] { 0x01 };
+            s = CombineByteArrays(s, v.Atom);
+            return Sha256Hash(s);
+        }
+    }
+    
+    private static byte[] CombineByteArrays(params byte[][] arrays)
+    {
+        int totalLength = arrays.Sum(array => array.Length);
+        byte[] result = new byte[totalLength];
+        int currentIndex = 0;
+
+        foreach (byte[] array in arrays)
+        {
+            Buffer.BlockCopy(array, 0, result, currentIndex, array.Length);
+            currentIndex += array.Length;
+        }
+
+        return result;
+    }
+    
+    private static byte[] Sha256Hash(byte[] input)
+    {
+        using (SHA256 sha256 = SHA256.Create())
+        {
+            return sha256.ComputeHash(input);
+        }
+    }
+}

--- a/CLVMDotNet/CLVMDotNet.Tools/SyntaxException.cs
+++ b/CLVMDotNet/CLVMDotNet.Tools/SyntaxException.cs
@@ -1,0 +1,8 @@
+namespace CLVMDotNet.Tools;
+
+public class SyntaxException : Exception
+{
+    public SyntaxException(string message) : base(message)
+    {
+    }
+}

--- a/CLVMDotNet/CLVMDotNet.sln
+++ b/CLVMDotNet/CLVMDotNet.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CLVMDotNet", "src\CLVMDotNe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CLVMDotNet.Tests", "tests\CLVMDotNet.Tests.csproj", "{06B05FF5-B8BA-4B71-B6AA-888D8A0DE971}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CLVMDotNet.Tools", "CLVMDotNet.Tools\CLVMDotNet.Tools.csproj", "{522C44D1-C816-4707-B0E7-62406E53A473}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{06B05FF5-B8BA-4B71-B6AA-888D8A0DE971}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{06B05FF5-B8BA-4B71-B6AA-888D8A0DE971}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06B05FF5-B8BA-4B71-B6AA-888D8A0DE971}.Release|Any CPU.Build.0 = Release|Any CPU
+		{522C44D1-C816-4707-B0E7-62406E53A473}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{522C44D1-C816-4707-B0E7-62406E53A473}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{522C44D1-C816-4707-B0E7-62406E53A473}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{522C44D1-C816-4707-B0E7-62406E53A473}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/CLVMDotNet/CLVMDotNet.sln
+++ b/CLVMDotNet/CLVMDotNet.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CLVMDotNet.Tests", "tests\C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CLVMDotNet.Tools", "CLVMDotNet.Tools\CLVMDotNet.Tools.csproj", "{522C44D1-C816-4707-B0E7-62406E53A473}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CLVMDotNet.Tools.Tests", "CLVMDotNet.Tools.Tests\CLVMDotNet.Tools.Tests.csproj", "{189BE2EB-5ABF-46C8-96B7-39CD0A227D76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{522C44D1-C816-4707-B0E7-62406E53A473}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{522C44D1-C816-4707-B0E7-62406E53A473}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{522C44D1-C816-4707-B0E7-62406E53A473}.Release|Any CPU.Build.0 = Release|Any CPU
+		{189BE2EB-5ABF-46C8-96B7-39CD0A227D76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{189BE2EB-5ABF-46C8-96B7-39CD0A227D76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{189BE2EB-5ABF-46C8-96B7-39CD0A227D76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{189BE2EB-5ABF-46C8-96B7-39CD0A227D76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/CLVMDotNet/src/CLVMObject.cs
+++ b/CLVMDotNet/src/CLVMObject.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace CLVMDotNet;
 
 using System;
@@ -9,7 +11,7 @@ using System;
 public class CLVMObject
 {
     public dynamic? Atom { get; set; }
-    public Tuple<dynamic, dynamic>? Pair { get; set; }
+    public Tuple<dynamic?, dynamic?>? Pair { get; set; }
 
     public CLVMObject(dynamic? v)
     {
@@ -23,7 +25,19 @@ public class CLVMObject
         {
             //valid tuple
             Atom = null;
-            Pair = v;
+
+            if (v is Tuple<BigInteger, BigInteger> bi)
+                Pair = new Tuple<dynamic?, dynamic?>(bi.Item1, bi.Item2);
+            else if (v is Tuple<SExp, SExp> sexp)
+                Pair = new Tuple<dynamic?, dynamic?>(sexp.Item1, sexp.Item2);
+            else if (v is Tuple<CLVMObject, CLVMObject> clvm)
+                Pair = new Tuple<dynamic?, dynamic?>(clvm.Item1, clvm.Item2);
+            else if (v is Tuple<BigInteger, int> mixint)
+                Pair = new Tuple<dynamic?, dynamic?>(mixint.Item1, mixint.Item2);
+            else
+            {
+                Pair = v;
+            }
         }
         else
         {
@@ -37,7 +51,7 @@ public class CLVMObject
             {
                 throw new ArgumentException("tuples must be of size 2");
             }
-            
+
             //v is an atom, which means it can be any type (string,byte,byte[],[],sexp etc)
             Pair = null;
             Atom = v;

--- a/CLVMDotNet/src/CLVMObject.cs
+++ b/CLVMDotNet/src/CLVMObject.cs
@@ -25,19 +25,7 @@ public class CLVMObject
         {
             //valid tuple
             Atom = null;
-
-            if (v is Tuple<BigInteger, BigInteger> bi)
-                Pair = new Tuple<dynamic?, dynamic?>(bi.Item1, bi.Item2);
-            else if (v is Tuple<SExp, SExp> sexp)
-                Pair = new Tuple<dynamic?, dynamic?>(sexp.Item1, sexp.Item2);
-            else if (v is Tuple<CLVMObject, CLVMObject> clvm)
-                Pair = new Tuple<dynamic?, dynamic?>(clvm.Item1, clvm.Item2);
-            else if (v is Tuple<BigInteger, int> mixint)
-                Pair = new Tuple<dynamic?, dynamic?>(mixint.Item1, mixint.Item2);
-            else
-            {
-                Pair = v;
-            }
+            Pair = new Tuple<dynamic?, dynamic?>(v?.Item1, v?.Item2);
         }
         else
         {

--- a/CLVMDotNet/src/HelperFunctions.cs
+++ b/CLVMDotNet/src/HelperFunctions.cs
@@ -154,17 +154,20 @@ namespace CLVMDotNet
                 {
                     var leftValue = new CLVMObject(stack[stack.Count - 1]);
                     stack.RemoveAt(stack.Count - 1);
-                    var currentPair = stack[target];
-                    stack[target].Pair = Tuple.Create<dynamic,dynamic>(leftValue, currentPair.Pair.Item2);
+                    var rightValue = stack[target].Pair.Item2;
+                    stack[target].Pair = Tuple.Create<dynamic,dynamic>(leftValue, rightValue);
                     continue;
                 }
 
                 if (op == 2) // set right
                 {
-                    var rightValue = new CLVMObject(stack[stack.Count - 1]);
+
+                    var leftValue = stack[target].Pair.Item1;
+                    var right = stack[stack.Count - 1];
                     stack.RemoveAt(stack.Count - 1);
-                    var currentPair = stack[target];
-                    stack[target].Pair = Tuple.Create<dynamic,dynamic>(currentPair.Pair.Item1, rightValue);
+                    var rightValue = new CLVMObject(right);
+
+                    stack[target].Pair = Tuple.Create<dynamic,dynamic>(leftValue, rightValue);
                     continue;
                 }
 

--- a/CLVMDotNet/src/HelperFunctions.cs
+++ b/CLVMDotNet/src/HelperFunctions.cs
@@ -1,13 +1,23 @@
+using System.Data.SqlTypes;
+using System.Numerics;
 using System.Reflection;
 using System.Text;
 
 namespace CLVMDotNet
 {
-
+    
     public static class HelperFunctions
     {
         private static byte[] nullBytes = new byte[0];
 
+        public static bool IsTuple(dynamic obj) => obj switch
+        {
+            Tuple<int, int> => true,
+            Tuple<object,object> => true,
+            Tuple<BigInteger, BigInteger> => true,
+            _ => false
+        };
+        
         public static dynamic? ToSexpType(dynamic? v)
         {
             List<dynamic> stack = new List<dynamic>() { v };
@@ -32,18 +42,18 @@ namespace CLVMDotNet
                     dynamic value = stack[stack.Count - 1];
                     stack.RemoveAt(stack.Count - 1);
 
-                    if (value is Tuple<object, object> tuple)
+                    if (IsTuple(value))
                     {
-                        if (tuple.Item2 != null)
+                        if (value.Item2 != null)
                         {
-                            stack.Add(tuple.Item2);
+                            stack.Add(value.Item2);
                             ops.Add((2, target)); // set right
                             ops.Add((0, -1)); // convert
                         }
 
-                        if (tuple.Item1 != null)
+                        if (value.Item1 != null)
                         {
-                            stack.Add(tuple.Item1);
+                            stack.Add(value.Item1);
                             ops.Add((1, target)); // set left
                             ops.Add((0, -1)); // convert
                         }
@@ -132,6 +142,12 @@ namespace CLVMDotNet
             if (v is int intValue)
             {
                 var s = Casts.IntToBytes(intValue);
+                return s;
+            }
+            
+            if (v is BigInteger bigIntValue)
+            {
+                var s = Casts.IntToBytes(bigIntValue);
                 return s;
             }
 

--- a/CLVMDotNet/src/HelperFunctions.cs
+++ b/CLVMDotNet/src/HelperFunctions.cs
@@ -125,7 +125,7 @@ namespace CLVMDotNet
                         continue;
                     }
 
-                    else if (value != null && value.GetType().IsArray)
+                    else if (value != null && value.GetType().IsArray && value is not byte[])
                     {
                         target = stack.Count;
                         stack.Add(new CLVMObject(nullBytes));

--- a/CLVMDotNet/src/SExp.cs
+++ b/CLVMDotNet/src/SExp.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using System.Security.Cryptography;
 using System.Text;
 
 //  SExp provides higher level API on top of any object implementing the CLVM
@@ -58,21 +59,21 @@ namespace CLVMDotNet
             return To(new Tuple<dynamic, dynamic>(this, right));
         }
 
-        public SExp First()
+        public dynamic First()
         {
-            if (Pair != null)
+            if (Pair is (_,_))
             {
-                return Pair.Item1;
+                return new SExp(Pair.Item1);
             }
 
             throw new EvalError("first of non-cons", this);
         }
 
-        public SExp Rest()
+        public dynamic Rest()
         {
-            if (Pair != null)
+            if (Pair is (_,_))
             {
-                return Pair.Item2;
+                return new SExp(Pair.Item2);
             }
 
             throw new EvalError("rest of non-cons", this);
@@ -109,7 +110,8 @@ namespace CLVMDotNet
                 return new SExp(v);
             }
 
-            return new SExp(HelperFunctions.ToSexpType(v));
+            var sexp = new SExp(HelperFunctions.ToSexpType(v));
+            return sexp;
         }
 
         public BigInteger AsInt()

--- a/CLVMDotNet/src/SExp.cs
+++ b/CLVMDotNet/src/SExp.cs
@@ -23,10 +23,13 @@ namespace CLVMDotNet
         public byte[]? Atom { get; set; }
         public Tuple<dynamic, dynamic>? Pair { get; set; }
 
-        public SExp(CLVMObject? obj)
+        public SExp(dynamic? obj)
         {
-            Atom = obj.Atom;
-            Pair = obj.Pair;
+            Atom = obj?.Atom;
+            if (obj?.Pair is (_, _))
+                Pair = Tuple.Create<dynamic, dynamic>(obj?.Pair.Item1, obj?.Pair.Item2);
+            else
+                Pair = null;
         }
 
         public SExp()

--- a/CLVMDotNet/src/SExp.cs
+++ b/CLVMDotNet/src/SExp.cs
@@ -159,7 +159,6 @@ namespace CLVMDotNet
         {
             try
             {
-                var thisob = this;
                 var otherObj = SExp.To(other);
                 Stack<(SExp, SExp)> toCompareStack = new Stack<(SExp, SExp)>();
                 toCompareStack.Push((this, otherObj));

--- a/CLVMDotNet/src/Serialize.cs
+++ b/CLVMDotNet/src/Serialize.cs
@@ -161,7 +161,7 @@ namespace CLVMDotNet
             while (todoStack.Count > 0)
             {
                 var p = todoStack.Pop();
-                Tuple<dynamic, dynamic>? pair = p.Pair;
+                Tuple<object, object>? pair = p.Pair;
 
                 if (pair != null)
                 {

--- a/CLVMDotNet/tests/BLS/TestStream.cs
+++ b/CLVMDotNet/tests/BLS/TestStream.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace CLVMDotNet.Tests.BLS;
+
+[Trait("BLS", "TestStream")]
+public class TestStream
+{
+    [Fact]
+    public void TestBLSStream()
+    {
+        
+    }
+}

--- a/CLVMDotNet/tests/SExp/AsBin.cs
+++ b/CLVMDotNet/tests/SExp/AsBin.cs
@@ -1,7 +1,7 @@
 using Xunit;
 using clvm = CLVMDotNet;
 
-namespace clvm_dotnet.tests.SExp;
+namespace CLVMDotNet.Tests.SExp;
 [Trait("SExp", "AsBin")]
 public class AsBin
 {

--- a/CLVMDotNet/tests/SExp/AsInt.cs
+++ b/CLVMDotNet/tests/SExp/AsInt.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace CLVMDotNet.Tests.SExp;
+
+[Trait("SExp", "AsInt")]
+public class AsInt
+{
+    
+}

--- a/CLVMDotNet/tests/SExp/Equals.cs
+++ b/CLVMDotNet/tests/SExp/Equals.cs
@@ -1,9 +1,17 @@
 using Xunit;
+using x = CLVMDotNet;
 
 namespace CLVMDotNet.Tests.SExp;
 
 [Trait("SExp", "Equal")]
 public class Equals
 {
-    
+    [Fact]
+    public void Two_identical_sexp_are_equal()
+    {
+        var s = x.SExp.To(new dynamic[] { "+", 1, 2 });
+        var t = x.SExp.To(new dynamic[] { "+", 1, 2 });
+        var isEqual = t.Equals(s);
+        Assert.True(isEqual);
+    }
 }

--- a/CLVMDotNet/tests/SExp/GeneratedTree.cs
+++ b/CLVMDotNet/tests/SExp/GeneratedTree.cs
@@ -1,0 +1,40 @@
+namespace CLVMDotNet.Tests.SExp;
+
+public class GeneratedTree
+{
+    public int Depth { get; private set; } = 4;
+    public int Val { get; private set; } = 0;
+
+    public GeneratedTree(int depth, int val)
+    {
+        if (depth < 0)
+            throw new ArgumentException("Depth must be greater than or equal to 0.");
+
+        Depth = depth;
+        Val = val;
+    }
+
+    public byte[] Atom
+    {
+        get
+        {
+            if (Depth > 0)
+                return null;
+
+            return new byte[] { (byte)Val };
+        }
+    }
+
+    public Tuple<GeneratedTree, GeneratedTree> Pair
+    {
+        get
+        {
+            if (Depth == 0)
+                return null;
+
+            int newDepth = Depth - 1;
+            return new Tuple<GeneratedTree, GeneratedTree>(new GeneratedTree(newDepth, Val),
+                new GeneratedTree(newDepth, Val + (int)Math.Pow(2, newDepth)));
+        }
+    }
+}

--- a/CLVMDotNet/tests/SExp/ListLength.cs
+++ b/CLVMDotNet/tests/SExp/ListLength.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace CLVMDotNet.Tests.SExp;
+
+[Trait("SExp", "ListLength")]
+public class ListLength
+{
+    
+}

--- a/CLVMDotNet/tests/SExp/Listp.cs
+++ b/CLVMDotNet/tests/SExp/Listp.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace CLVMDotNet.Tests.SExp;
+
+[Trait("SExp", "Listp")]
+public class Listp
+{
+    
+}

--- a/CLVMDotNet/tests/SExp/Rest.cs
+++ b/CLVMDotNet/tests/SExp/Rest.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace CLVMDotNet.Tests.SExp;
+
+[Trait("SExp", "Rest")]
+public class Rest
+{
+    
+}

--- a/CLVMDotNet/tests/SExp/To.cs
+++ b/CLVMDotNet/tests/SExp/To.cs
@@ -8,6 +8,15 @@ namespace clvm_dotnet.tests.Serialize;
 public class To
 {
     [Fact]
+    public void builds_correct_tree()
+    {
+        var s = clvm.SExp.To(new dynamic[] { "+", 1, 2});
+        var t = s;
+        var tree = Common.PrintTree(t);
+        Assert.Equal("(43 (1 (2 () )))", tree);
+    }
+    
+    [Fact]
     public void test_case_1()
     {
         var sexp = clvm.SExp.To(Encoding.UTF8.GetBytes("foo"));

--- a/CLVMDotNet/tests/SExp/To.cs
+++ b/CLVMDotNet/tests/SExp/To.cs
@@ -1,8 +1,9 @@
 using System.Text;
+using clvm_dotnet.tests;
 using Xunit;
 using clvm = CLVMDotNet;
 
-namespace clvm_dotnet.tests.Serialize;
+namespace CLVMDotNet.Tests.SExp;
 
 [Trait("SExp", "To")]
 public class To

--- a/CLVMDotNet/tests/SExp/To.cs
+++ b/CLVMDotNet/tests/SExp/To.cs
@@ -11,12 +11,12 @@ public class To
     [Fact]
     public void builds_correct_tree()
     {
-        var s = clvm.SExp.To(new dynamic[] { "+", 1, 2});
+        var s = clvm.SExp.To(new dynamic[] { "+", 1, 2 });
         var t = s;
         var tree = Common.PrintTree(t);
         Assert.Equal("(43 (1 (2 () )))", tree);
     }
-    
+
     [Fact]
     public void test_case_1()
     {
@@ -24,16 +24,16 @@ public class To
         var t1 = clvm.SExp.To(new dynamic[] { 1, sexp });
         Common.ValidateSExp(t1);
     }
-    
+
     [Fact]
     public void TestListConversions()
     {
         var a = clvm.SExp.To(new object[] { 1, 2, 3 });
         string expectedOutput = "(1 (2 (3 () )))";
-        string result = Common.PrintTree(a);       
+        string result = Common.PrintTree(a);
         Assert.Equal(expectedOutput, result);
     }
-    
+
     [Fact]
     public void TestNullConversions()
     {
@@ -41,7 +41,7 @@ public class To
         byte[] expected = Array.Empty<byte>();
         Assert.Equal(expected, a.AsAtom());
     }
-    
+
     [Fact]
     public void empty_list_conversions()
     {
@@ -49,12 +49,36 @@ public class To
         byte[] expected = new byte[0];
         Assert.Equal(expected, a.AsAtom());
     }
-    
+
     [Fact]
     public void int_conversions()
     {
         var a = clvm.SExp.To(1337);
         byte[] expected = new byte[] { 0x5, 0x39 };
         Assert.Equal(expected, a.AsAtom());
+    }
+
+
+    [Fact]
+    // SExp provides a view on top of a tree of arbitrary types, as long as
+    // those types implement the CLVMObject protocol. This is an example of
+    // a tree that's generate
+    //
+    // There is a subtle differences between the python version and the 
+    // c# version of representing trees. 
+    public void arbitrary_underlying_tree()
+    {
+        var gentree1 = new GeneratedTree(5, 0);
+        var tree1 = clvm.SExp.To(gentree1);
+        Assert.Equal(Common.PrintTree(tree1), "(((((0 1 )(2 3 ))((4 5 )(6 7 )))(((8 9 )(10 11 ))((12 13 )(14 15 ))))((((16 17 )(18 19 ))((20 21 )(22 23 )))(((24 25 )(26 27 ))((28 29 )(30 31 )))))");
+        
+        
+        var gentree2 = new GeneratedTree(3, 0);
+        var tree2 = clvm.SExp.To(gentree2);
+        Assert.Equal(Common.PrintTree(tree2), "(((0 1 )(2 3 ))((4 5 )(6 7 )))");
+
+        var gentree3 = new GeneratedTree(3, 10);
+        var tree3 = clvm.SExp.To(gentree3);
+        Assert.Equal(Common.PrintTree(tree3), "(((10 11 )(12 13 ))((14 15 )(16 17 )))");
     }
 }

--- a/WHATSLEFT.md
+++ b/WHATSLEFT.md
@@ -1,9 +1,0 @@
-This has been pretty much a straight port from the chia clvm repo, with converting the existing code written in python as per my understanding of what it was doing. Perhaps we can maintain a table of what needs doing and who is picking it up.
-
-
-| Code | Description | Who is working on it |
-| -------- | ------- |
-| More_Options | the bulk of the implementation needs completing. |  |
-| All tests | tests | |
-| | | |
-


### PR DESCRIPTION
In seems sensible to add the clvm tools to the project first before proceeding with any more clvm. This is because to be able to write meaningful tests for the CLVM, we want real data that would be passed in to build a SExp object (SExp.To())

# Work to complete

## Reader
- [x]  consume_whitespace
- [x] consume_until_whitespace
- [x] next_cons_token
- [x] tokenize_cons
- [x] tokenize_int
- [x] tokenize_hex
- [x] tokenize_quotes
- [x] tokenize_symbol
- [x] tokenize_sexp

## Writer
- [x] iter_sexp_format
- [x] iter_ir_format
- [x] write_ir_to_stream
- [x] write_ir

## Utils
- [x] ir_new
- [x] ir_cons
- [x] ir_list
- [x] ir_null
- [x] ir_type
- [x] ir_as_int

## BinUtils
- [ ] assemble_from_ir
- [ ] type_for_atom
- [ ] disassemble_to_ir
- [ ] disassemble
- [ ] assemble

## clvmc
- [ ] compile_clvm_text
- [ ] compile_clvm
- [ ] find_files

## Curry
- [ ] curry
- [ ] uncurry

# SHA256Tree
- [ ] sha256tree


